### PR TITLE
Bugfix/absolute value

### DIFF
--- a/EngineeringUnits/BaseUnit.cs
+++ b/EngineeringUnits/BaseUnit.cs
@@ -282,15 +282,13 @@ namespace EngineeringUnits
         public UnknownUnit Abs()
         {
             BaseUnit local = new BaseUnit();
-            local.Unit = Unit;
-
-            if (SymbolValue < 0)            
-                SymbolValue *= -1;
-            
+            local.Unit = Unit.Copy();
             local.SymbolValue = SymbolValue;
 
+            if (local.SymbolValue < 0)
+                local.SymbolValue *= -1;
+            
             return local;
-
         }
 
         public UnknownUnit Pow(int toPower)

--- a/UnitTests/Math/AbsoluteValue.cs
+++ b/UnitTests/Math/AbsoluteValue.cs
@@ -1,0 +1,59 @@
+using EngineeringUnits;
+using EngineeringUnits.Units;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests
+{
+    [TestClass]
+    public class AbsoluteValue
+    {
+        [TestMethod]
+        public void TestAbsoluteValue01()
+        {
+            Frequency f1 = Frequency.FromMegahertz(-32);
+
+            string toString = f1.ToString();
+
+            Frequency f2 = f1.Abs();
+
+            Assert.AreEqual(toString, f1.ToString()); // calling Abs should not mutate F1 if it returns F2
+        }
+
+        [TestMethod]
+        public void TestAbsoluteValue02()
+        {
+            Frequency f1 = Frequency.FromMegahertz(32);
+            decimal baseUnitValue = f1.BaseunitValue;
+            string toString = f1.ToString();
+            Frequency f2 = f1.Abs();
+            UnknownUnit f3 = f1.Abs();
+
+            Assert.AreEqual(baseUnitValue, f1.BaseunitValue);
+            Assert.AreEqual(baseUnitValue, f2.BaseunitValue);
+            Assert.AreEqual(baseUnitValue, ((BaseUnit)f3).BaseunitValue);
+
+            Assert.AreEqual(toString, f1.ToString());
+            Assert.AreEqual(toString, f2.ToString());
+            Assert.AreEqual(toString, f3.ToString());
+        }
+
+        [TestMethod]
+        public void TestAbsoluteValue03()
+        {
+            Frequency f0 = Frequency.FromMegahertz(32);
+            decimal baseUnitValue = f0.BaseunitValue;
+            string toString = f0.ToString();
+
+            Frequency f1 = Frequency.FromMegahertz(-32);
+
+            Frequency f2 = f1.Abs();
+            UnknownUnit f3 = f1.Abs();
+
+            Assert.AreEqual(baseUnitValue, f2.BaseunitValue);
+            Assert.AreEqual(baseUnitValue, ((BaseUnit)f3).BaseunitValue);
+
+            Assert.AreEqual(toString, f2.ToString());
+            Assert.AreEqual(toString, f3.ToString());
+        }
+    }
+}


### PR DESCRIPTION
A couple of points here:

- Since `Abs()` returns an `UnknownUnit` rather than `void`, I assume the return value is supposed to contain the absolute value. But I found the underlying value was also mutated -- calling `Abs()` on a negative quantity changed it to a positive quantity, so I lost my original value. This is noted in test case 01 and is resolved by my pull request.

- Not resolved by this pull request, I think it would be desirable if the unit prefix was fully preserved through this operation. So the absolute value of `-32 MHz` could be written by the `ToString()` method as `32 MHz` rather than `-3.2e7 Hz`. I understand this is a broader change and may not be considered urgent or important right now.