### PR TITLE
Adding IsNaN method

### DIFF
--- a/EngineeringUnits/BaseUnitExtensions.cs
+++ b/EngineeringUnits/BaseUnitExtensions.cs
@@ -199,6 +199,19 @@ namespace EngineeringUnits
             return a.GetBaseValue() < 0;
         }
 
+        /// <summary>
+        /// Determines whether the specified Unit is NaN.
+        /// </summary>
+        /// <param name="a">The BaseUnit to check.</param>
+        /// <returns>True if the BaseUnit is NaN; otherwise, false.</returns>
+        public static bool IsNaN(this BaseUnit a)
+        {
+            if (a is null)
+                return false;
+
+            return double.IsNaN(a.Value); // TODO: avoid using deprecated .Value here
+        }
+
 
 
         /// <summary>

--- a/EngineeringUnits/BaseUnitExtensions.cs
+++ b/EngineeringUnits/BaseUnitExtensions.cs
@@ -209,7 +209,9 @@ namespace EngineeringUnits
             if (a is null)
                 return false;
 
-            return double.IsNaN(a.Value); // TODO: avoid using deprecated .Value here
+            //return double.IsNaN(a.Value); // TODO: avoid using deprecated .Value here
+            //return double.IsNaN(a.GetValueAsDouble(UnitSystemExtensions.UnitsystemForDouble));
+            return double.IsNaN(a.As(UnitSystemExtensions.UnitsystemForDouble));
         }
 
 

--- a/EngineeringUnits/BaseUnits/Temperature/Temperature.cs
+++ b/EngineeringUnits/BaseUnits/Temperature/Temperature.cs
@@ -105,6 +105,7 @@ namespace EngineeringUnits
             return new Temperature(this.GetValueAs(selectedUnit.Unit), selectedUnit, false);
         }
         public static Temperature Zero => new(0, TemperatureUnit.SI);
+        public static Temperature NaN => new(double.NaN, TemperatureUnit.SI);
 
         //public static implicit operator Temperature(UnknownUnit Unit) => new(Unit);
 

--- a/UnitTests/Functionality/IsNaN.cs
+++ b/UnitTests/Functionality/IsNaN.cs
@@ -14,9 +14,11 @@ namespace UnitTests.Functionality
         {
             Mass mass1 = new Mass(double.NaN, MassUnit.SI);
             Mass mass2 = Mass.FromCentigram(double.NaN);
+            Mass mass3 = Mass.FromCentigram(5);
 
             Assert.IsTrue(mass1.IsNaN());
             Assert.IsTrue(mass2.IsNaN());
+            Assert.IsFalse(mass3.IsNaN());
 
             // old check. could remove ...........
             double nan1 = mass1.SI;

--- a/UnitTests/Functionality/IsNaN.cs
+++ b/UnitTests/Functionality/IsNaN.cs
@@ -1,6 +1,7 @@
 ﻿using EngineeringUnits;
 using EngineeringUnits.Units;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using static EngineeringUnits.BaseUnitExtensions;
 
 
 namespace UnitTests.Functionality
@@ -11,33 +12,35 @@ namespace UnitTests.Functionality
         [TestMethod]
         public void IsNaNCheck()
         {
-
             Mass mass1 = new Mass(double.NaN, MassUnit.SI);
-
             Mass mass2 = Mass.FromCentigram(double.NaN);
 
+            Assert.IsTrue(mass1.IsNaN());
+            Assert.IsTrue(mass2.IsNaN());
+
+            // old check. could remove ...........
             double nan1 = mass1.SI;
-
             double nan2 = mass2.Gram;
-
             Assert.AreEqual(nan1, double.NaN);
             Assert.AreEqual(nan2, double.NaN);
+            // ....................................
         }
 
         [TestMethod]
         public void IsNaNCheckTemperature()
         {
-
             Temperature temp1 = new Temperature(double.NaN, TemperatureUnit.SI);
-
             Temperature temp2 = Temperature.FromKelvins(double.NaN);
 
+            Assert.IsTrue(temp1.IsNaN());
+            Assert.IsTrue(temp2.IsNaN());
+
+            // old check. could remove ...........
             double nan1 = temp1.SI;
-
             double nan2 = temp2.DegreesCelsius;
-
             Assert.AreEqual(nan1, double.NaN);
             Assert.AreEqual(nan2, double.NaN);
+            // ....................................
         }
     }
 }

--- a/UnitTests/Functionality/IsNaN.cs
+++ b/UnitTests/Functionality/IsNaN.cs
@@ -11,24 +11,29 @@ public class IsNaN
     [TestMethod]
     public void IsNaNCheck()
     {
-        Mass mass1 = new Mass(double.NaN, MassUnit.SI);
-        Mass mass2 = Mass.FromCentigram(double.NaN);
-        Mass mass3 = Mass.FromCentigram(5);
+        Mass massNan1 = new Mass(double.NaN, MassUnit.SI);
+        Mass massNan2 = Mass.FromCentigram(double.NaN);
+        Mass massNan3 = Mass.NaN;
 
-        Assert.IsTrue(mass1.IsNaN());
-        Assert.IsTrue(mass2.IsNaN());
-        Assert.IsFalse(mass3.IsNaN());
+        Mass massNotNan1 = Mass.FromCentigram(5);
+
+        Assert.IsTrue(massNan1.IsNaN());
+        Assert.IsTrue(massNan2.IsNaN());
+        Assert.IsTrue(massNan3.IsNaN());
+
+        Assert.IsFalse(massNotNan1.IsNaN());
     }
 
     [TestMethod]
     public void IsNaNCheckTemperature()
     {
-        Temperature temp1 = new Temperature(double.NaN, TemperatureUnit.SI);
-        Temperature temp2 = Temperature.FromKelvins(double.NaN);
-        Temperature temp3 = Temperature.FromDegreesCelsius(20);
+        Temperature tempNan1 = new Temperature(double.NaN, TemperatureUnit.SI);
+        Temperature tempNan2 = Temperature.FromKelvins(double.NaN);
 
-        Assert.IsTrue(temp1.IsNaN());
-        Assert.IsTrue(temp2.IsNaN());
-        Assert.IsFalse(temp3.IsNaN());
+        Temperature tempNotNan1 = Temperature.FromDegreesCelsius(20);
+
+        Assert.IsTrue(tempNan1.IsNaN());
+        Assert.IsTrue(tempNan2.IsNaN());
+        Assert.IsFalse(tempNotNan1.IsNaN());
     }
 }

--- a/UnitTests/Functionality/IsNaN.cs
+++ b/UnitTests/Functionality/IsNaN.cs
@@ -29,11 +29,13 @@ public class IsNaN
     {
         Temperature tempNan1 = new Temperature(double.NaN, TemperatureUnit.SI);
         Temperature tempNan2 = Temperature.FromKelvins(double.NaN);
+        Temperature tempNan3 = Temperature.NaN;
 
         Temperature tempNotNan1 = Temperature.FromDegreesCelsius(20);
 
         Assert.IsTrue(tempNan1.IsNaN());
         Assert.IsTrue(tempNan2.IsNaN());
+        Assert.IsTrue(tempNan3.IsNaN());
         Assert.IsFalse(tempNotNan1.IsNaN());
     }
 }

--- a/UnitTests/Functionality/IsNaN.cs
+++ b/UnitTests/Functionality/IsNaN.cs
@@ -3,48 +3,32 @@ using EngineeringUnits.Units;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using static EngineeringUnits.BaseUnitExtensions;
 
+namespace UnitTests.Functionality;
 
-namespace UnitTests.Functionality
+[TestClass]
+public class IsNaN
 {
-    [TestClass]
-    public class IsNaN
+    [TestMethod]
+    public void IsNaNCheck()
     {
-        [TestMethod]
-        public void IsNaNCheck()
-        {
-            Mass mass1 = new Mass(double.NaN, MassUnit.SI);
-            Mass mass2 = Mass.FromCentigram(double.NaN);
-            Mass mass3 = Mass.FromCentigram(5);
+        Mass mass1 = new Mass(double.NaN, MassUnit.SI);
+        Mass mass2 = Mass.FromCentigram(double.NaN);
+        Mass mass3 = Mass.FromCentigram(5);
 
-            Assert.IsTrue(mass1.IsNaN());
-            Assert.IsTrue(mass2.IsNaN());
-            Assert.IsFalse(mass3.IsNaN());
+        Assert.IsTrue(mass1.IsNaN());
+        Assert.IsTrue(mass2.IsNaN());
+        Assert.IsFalse(mass3.IsNaN());
+    }
 
-            // old check. could remove ...........
-            double nan1 = mass1.SI;
-            double nan2 = mass2.Gram;
-            Assert.AreEqual(nan1, double.NaN);
-            Assert.AreEqual(nan2, double.NaN);
-            // ....................................
-        }
+    [TestMethod]
+    public void IsNaNCheckTemperature()
+    {
+        Temperature temp1 = new Temperature(double.NaN, TemperatureUnit.SI);
+        Temperature temp2 = Temperature.FromKelvins(double.NaN);
+        Temperature temp3 = Temperature.FromDegreesCelsius(20);
 
-        [TestMethod]
-        public void IsNaNCheckTemperature()
-        {
-            Temperature temp1 = new Temperature(double.NaN, TemperatureUnit.SI);
-            Temperature temp2 = Temperature.FromKelvins(double.NaN);
-            Temperature temp3 = Temperature.FromDegreesCelsius(20);
-
-            Assert.IsTrue(temp1.IsNaN());
-            Assert.IsTrue(temp2.IsNaN());
-            Assert.IsFalse(temp3.IsNaN());
-
-            // old check. could remove ...........
-            double nan1 = temp1.SI;
-            double nan2 = temp2.DegreesCelsius;
-            Assert.AreEqual(nan1, double.NaN);
-            Assert.AreEqual(nan2, double.NaN);
-            // ....................................
-        }
+        Assert.IsTrue(temp1.IsNaN());
+        Assert.IsTrue(temp2.IsNaN());
+        Assert.IsFalse(temp3.IsNaN());
     }
 }

--- a/UnitTests/Functionality/IsNaN.cs
+++ b/UnitTests/Functionality/IsNaN.cs
@@ -33,9 +33,11 @@ namespace UnitTests.Functionality
         {
             Temperature temp1 = new Temperature(double.NaN, TemperatureUnit.SI);
             Temperature temp2 = Temperature.FromKelvins(double.NaN);
+            Temperature temp3 = Temperature.FromDegreesCelsius(20);
 
             Assert.IsTrue(temp1.IsNaN());
             Assert.IsTrue(temp2.IsNaN());
+            Assert.IsFalse(temp3.IsNaN());
 
             // old check. could remove ...........
             double nan1 = temp1.SI;


### PR DESCRIPTION
```csharp
Mass m = Mass.NaN;
```

Can now do

```csharp
bool test = m.IsNaN();
```

instead of 

```csharp
bool test = double.IsNaN(m.SI);
```