### PR TITLE
NaN should be conserved when performing math operations

### DIFF
--- a/EngineeringUnits/BaseUnit.cs
+++ b/EngineeringUnits/BaseUnit.cs
@@ -68,6 +68,9 @@ namespace EngineeringUnits
             if (left.Unit != right.Unit)
                 throw new WrongUnitException($"Trying to do [{left.Unit}] + [{right.Unit}]. Can't add two different units!");
 
+            if (left.IsNaN() || right.IsNaN())
+                return new UnknownUnit(double.NaN, left.Unit);
+
             try
             {
                 if (left.Unit.SumOfBConstants() != Fraction.Zero || right.Unit.SumOfBConstants() != Fraction.Zero)
@@ -129,6 +132,9 @@ namespace EngineeringUnits
 
             if (left.Unit != right.Unit)
                 throw new WrongUnitException($"Trying to do [{left.Unit}] - [{right.Unit}]. Can't subtract two different units!");
+
+            if (left.IsNaN() || right.IsNaN())
+                return new UnknownUnit(double.NaN, left.Unit);
 
             try
             {
@@ -196,12 +202,14 @@ namespace EngineeringUnits
             if (left is null || right is null)
                 return null;
 
+            if (left.IsNaN() || right.IsNaN())
+                return new UnknownUnit(double.NaN, left.Unit * right.Unit);
+
             try
             {
                 if (left.Unit.SumOfBConstants() != Fraction.Zero || right.Unit.SumOfBConstants() != Fraction.Zero)
                 {
-
-                    //Showing a unit like 캜 as 캜^2 is not very useful (As I understand the conversion between 컆^2 and 캜^2 is not linear)
+                    //Showing a unit like 째C as 째C^2 is not very useful (As I understand the conversion between 째k^2 and 째C^2 is not linear)
                     //Therefore we will convert these units to their base unit
 
                     if (left.Unit.SumOfBConstants() != Fraction.Zero)
@@ -239,6 +247,9 @@ namespace EngineeringUnits
         }
         public static UnknownUnit operator *(BaseUnit left, int right)
         {
+            if (left.IsNaN())
+                return new UnknownUnit(double.NaN, left.Unit);
+
             return left * new BaseUnit(right);
         }
         public static UnknownUnit operator *(int left, BaseUnit right)
@@ -268,14 +279,15 @@ namespace EngineeringUnits
             if (left is null || right is null)
                 return null;
 
+            if (left.IsNaN() || right.IsNaN())
+                return new UnknownUnit(double.NaN, left.Unit / right.Unit);
+
             try
             {
 
                 if (left.Unit.SumOfBConstants() != Fraction.Zero || right.Unit.SumOfBConstants() != Fraction.Zero)
                 {
-
-
-                    //Showing a unit like 캜 as 캜^2 is not very useful (As I understand the conversion between 컆^2 and 캜^2 is not linear)
+                    //Showing a unit like 째C as 째C^2 is not very useful (As I understand the conversion between 째k^2 and 째C^2 is not linear)
                     //Therefore we will convert these units to their base unit
 
                     if (left.Unit.SumOfBConstants() != Fraction.Zero)

--- a/EngineeringUnits/BaseUnit.cs
+++ b/EngineeringUnits/BaseUnit.cs
@@ -173,6 +173,7 @@ namespace EngineeringUnits
                 return new UnknownUnit(double.PositiveInfinity, left.Unit - right.Unit);
             }
         }
+
         public static UnknownUnit operator -(BaseUnit local)
         {
             if (local is null)

--- a/UnitTests/Functionality/IsNaN.cs
+++ b/UnitTests/Functionality/IsNaN.cs
@@ -46,7 +46,41 @@ public class IsNaN
         Length lengthNan = Length.NaN;
 
         Length lengthSumShouldBeNan = lengthNotNan + lengthNan;
+        Length lengthPlusShouldBeNan = +lengthNan;
+        Length lengthDiffShouldBeNan1 = lengthNotNan - lengthNan;
+        Length lengthDiffShouldBeNan2 = lengthNan - lengthNotNan;
+        Length lengthMinusShouldBeNan = -lengthNan;
+        Area areaProdShouldBeNan1 = lengthNotNan * lengthNan;
+        Area areaProdShouldBeNan2 = lengthNan * lengthNotNan;
+        Ratio ratioDivShouldBeNan1 = lengthNotNan / lengthNan;
+        Ratio ratioDivShouldBeNan2 = lengthNan / lengthNotNan;
 
         Assert.IsTrue(lengthSumShouldBeNan.IsNaN());
+        Assert.IsTrue(lengthPlusShouldBeNan.IsNaN());
+        Assert.IsTrue(lengthDiffShouldBeNan1.IsNaN());
+        Assert.IsTrue(lengthDiffShouldBeNan2.IsNaN());
+        Assert.IsTrue(lengthMinusShouldBeNan.IsNaN());
+        Assert.IsTrue(areaProdShouldBeNan1.IsNaN());
+        Assert.IsTrue(areaProdShouldBeNan2.IsNaN());
+        Assert.IsTrue(ratioDivShouldBeNan1.IsNaN());
+        Assert.IsTrue(ratioDivShouldBeNan2.IsNaN());
+
+        double valNan = double.NaN;
+
+        Length lengthSumShouldBeNanD = lengthNotNan + valNan;
+        Length lengthDiffShouldBeNanD1 = lengthNotNan - valNan;
+        Length lengthDiffShouldBeNanD2 = valNan - lengthNotNan;
+        Length lengthProdShouldBeNanD1 = lengthNotNan * valNan;
+        Length lengthProdShouldBeNanD2 = valNan * lengthNotNan;
+        Length lengthDivShouldBeNanD1 = lengthNotNan / valNan;
+        Length lengthDivShouldBeNanD2 = valNan / lengthNotNan;
+
+        Assert.IsTrue(lengthSumShouldBeNanD.IsNaN());
+        Assert.IsTrue(lengthDiffShouldBeNanD1.IsNaN());
+        Assert.IsTrue(lengthDiffShouldBeNanD2.IsNaN());
+        Assert.IsTrue(lengthProdShouldBeNanD1.IsNaN());
+        Assert.IsTrue(lengthProdShouldBeNanD2.IsNaN());
+        Assert.IsTrue(lengthDivShouldBeNanD1.IsNaN());
+        Assert.IsTrue(lengthDivShouldBeNanD2.IsNaN());
     }
 }

--- a/UnitTests/Functionality/IsNaN.cs
+++ b/UnitTests/Functionality/IsNaN.cs
@@ -38,4 +38,15 @@ public class IsNaN
         Assert.IsTrue(tempNan3.IsNaN());
         Assert.IsFalse(tempNotNan1.IsNaN());
     }
+
+    [TestMethod]
+    public void NaNWithOperators()
+    {
+        Length lengthNotNan = Length.FromMeter(2);
+        Length lengthNan = Length.NaN;
+
+        Length lengthSumShouldBeNan = lengthNotNan + lengthNan;
+
+        Assert.IsTrue(lengthSumShouldBeNan.IsNaN());
+    }
 }

--- a/UnitTests/Functionality/IsNaN.cs
+++ b/UnitTests/Functionality/IsNaN.cs
@@ -67,17 +67,11 @@ public class IsNaN
 
         double valNan = double.NaN;
 
-        Length lengthSumShouldBeNanD = lengthNotNan + valNan;
-        Length lengthDiffShouldBeNanD1 = lengthNotNan - valNan;
-        Length lengthDiffShouldBeNanD2 = valNan - lengthNotNan;
         Length lengthProdShouldBeNanD1 = lengthNotNan * valNan;
         Length lengthProdShouldBeNanD2 = valNan * lengthNotNan;
         Length lengthDivShouldBeNanD1 = lengthNotNan / valNan;
         Length lengthDivShouldBeNanD2 = valNan / lengthNotNan;
 
-        Assert.IsTrue(lengthSumShouldBeNanD.IsNaN());
-        Assert.IsTrue(lengthDiffShouldBeNanD1.IsNaN());
-        Assert.IsTrue(lengthDiffShouldBeNanD2.IsNaN());
         Assert.IsTrue(lengthProdShouldBeNanD1.IsNaN());
         Assert.IsTrue(lengthProdShouldBeNanD2.IsNaN());
         Assert.IsTrue(lengthDivShouldBeNanD1.IsNaN());

--- a/UnitTests/Functionality/IsNaN.cs
+++ b/UnitTests/Functionality/IsNaN.cs
@@ -70,7 +70,7 @@ public class IsNaN
         Length lengthProdShouldBeNanD1 = lengthNotNan * valNan;
         Length lengthProdShouldBeNanD2 = valNan * lengthNotNan;
         Length lengthDivShouldBeNanD1 = lengthNotNan / valNan;
-        Length lengthDivShouldBeNanD2 = valNan / lengthNotNan;
+        var lengthDivShouldBeNanD2 = valNan / lengthNotNan;
 
         Assert.IsTrue(lengthProdShouldBeNanD1.IsNaN());
         Assert.IsTrue(lengthProdShouldBeNanD2.IsNaN());


### PR DESCRIPTION
... like for `double`

```csharp
var test = double.NaN + 1.0; // = double.NaN
```