### PR TITLE
Unit test unicode fixes

### DIFF
--- a/UnitTests/CombinedUnits/MolarEntropy/MolarEntropy.cs
+++ b/UnitTests/CombinedUnits/MolarEntropy/MolarEntropy.cs
@@ -50,7 +50,7 @@ public class MolarEntropyTest
                 //All units symbol compare
                 Assert.AreEqual(A2.ToUnit(EU).DisplaySymbol(),
                             A1.ToUnit(UN).ToString("a")
-                              .Replace("*", "·")
+                              .Replace("*", "Â·")
 
                             );
 

--- a/UnitTests/CombinedUnits/MolarEntropy/MolarEntropy.cs
+++ b/UnitTests/CombinedUnits/MolarEntropy/MolarEntropy.cs
@@ -48,11 +48,11 @@ public class MolarEntropyTest
                                                         RelError);
 
                 //All units symbol compare
-                Assert.AreEqual(A2.ToUnit(EU).DisplaySymbol(),
-                            A1.ToUnit(UN).ToString("a")
-                              .Replace("*", "·")
-
-                            );
+                Assert.AreEqual(
+                    A2.ToUnit(EU).DisplaySymbol(),
+                    A1.ToUnit(UN).ToString("a")
+                        .Replace('*', '\u00b7')
+                        );
 
                 WorkingCompares++;
 

--- a/UnitTests/ComparToUnitNetCombinedUnits.cs
+++ b/UnitTests/ComparToUnitNetCombinedUnits.cs
@@ -537,7 +537,7 @@ public class Angle
                                 A1.ToUnit(UN).ToString("a")
                                 .Replace(".", "*")
                                 .Replace("C", "K")
-                                .Replace("°F", "°R")
+                                .Replace("'°'F", "'\u00b0'R")
                                 .Replace('*', '\u00b7')
                                 );
 

--- a/UnitTests/ComparToUnitNetCombinedUnits.cs
+++ b/UnitTests/ComparToUnitNetCombinedUnits.cs
@@ -538,7 +538,7 @@ public class Angle
                                 .Replace(".", "*")
                                 .Replace("C", "K")
                                 .Replace("°F", "°R")
-                                .Replace("*", "·")
+                                .Replace('*', '\u00b7')
                                 );
 
                 WorkingCompares++;
@@ -900,7 +900,7 @@ public class Angle
                 Assert.AreEqual(
                     A2.ToUnit(EU).DisplaySymbol(),
                     A1.ToUnit(UN).ToString("a")
-                        .Replace("Ns", "N·s")
+                        .Replace("Ns", "N'\u00b7's")
                     );
 
                 WorkingCompares++;
@@ -1057,7 +1057,7 @@ public class Angle
                                 .Replace("day", "d")
                                 //.Replace("min", "m")
                                 .Replace("L", "l")
-                                .Replace("cy", "yd³")
+                                .Replace("cy", "yd'\u00b3'")
                                 .Replace("hr", "h")
                                 );
 
@@ -1258,8 +1258,11 @@ public class Angle
                                                         A1.As(UN)),
                                                         RelError);
                 //All units symbol compare
-                Assert.AreEqual(A2.ToUnit(EU).DisplaySymbol(),
-                                A1.ToUnit(UN).ToString("a").Replace("·", ""));
+                Assert.AreEqual(
+                    A2.ToUnit(EU).DisplaySymbol(),
+                    A1.ToUnit(UN).ToString("a")
+                        .Replace("'\u00b7'", "")
+                        );
 
                 WorkingCompares++;
             }

--- a/UnitTests/ComparToUnitNetCombinedUnits.cs
+++ b/UnitTests/ComparToUnitNetCombinedUnits.cs
@@ -537,8 +537,8 @@ public class Angle
                                 A1.ToUnit(UN).ToString("a")
                                 .Replace(".", "*")
                                 .Replace("C", "K")
-                                .Replace("°F", "°R")
-                                .Replace("*", "·")
+                                .Replace("Â°F", "Â°R")
+                                .Replace("*", "Â·")
                                 );
 
                 WorkingCompares++;
@@ -897,10 +897,11 @@ public class Angle
                                                         A1.As(UN)),
                                                         RelError);
                 //All units symbol compare
-                Assert.AreEqual(A2.ToUnit(EU).DisplaySymbol(),
-                                A1.ToUnit(UN).ToString("a")
-                                .Replace("Ns", "N·s")
-                                );
+                Assert.AreEqual(
+                    A2.ToUnit(EU).DisplaySymbol(),
+                    A1.ToUnit(UN).ToString("a")
+                        .Replace("Ns", "NÂ·s")
+                    );
 
                 WorkingCompares++;
 
@@ -1056,7 +1057,7 @@ public class Angle
                                 .Replace("day", "d")
                                 //.Replace("min", "m")
                                 .Replace("L", "l")
-                                .Replace("cy", "yd³")
+                                .Replace("cy", "ydÂ³")
                                 .Replace("hr", "h")
                                 );
 
@@ -1258,7 +1259,7 @@ public class Angle
                                                         RelError);
                 //All units symbol compare
                 Assert.AreEqual(A2.ToUnit(EU).DisplaySymbol(),
-                                A1.ToUnit(UN).ToString("a").Replace("·", ""));
+                                A1.ToUnit(UN).ToString("a").Replace("Â·", ""));
 
                 WorkingCompares++;
             }


### PR DESCRIPTION
Seems like it all has something to do with non-UTF-8 characters in UTF-8 files...

For some reason, whenever I happened to open the unit test source files in question in Visual Studio, it automatically did some changes on the "dot", "degree" and "cubed" characters. Weird thing was they then showed up in Visual Studio as `�` and in my local git diff as `�` -> `�`. It also wouldn't let me commit anything before reverting the changes and closing without saving.

You can see in my first two commits that I first attempted to fix it by pasting in the correct characters again, the assumption being that they might now be formatted correctly. And that seemed to work too. Interestingly, the diff on this pull request showed the characters replaced by the same characters (but encoded differently..?), e.g. `°` -> `°`.

Eventually, I figured these issues might have something to do with some local settings and that other users might have the same issues as I had before when opening the now changed files. Which is why I ten used the actual unicode, hoping that this is universally true.

Let me know what you think.

Btw, it seems like all these "comparison" tests are within the `Angle` class, which seems incorrect.