### PR TITLE
Actually fixing unicode symbols

### DIFF
--- a/UnitTests/ComparToUnitNetCombinedUnits.cs
+++ b/UnitTests/ComparToUnitNetCombinedUnits.cs
@@ -537,7 +537,7 @@ public class Angle
                                 A1.ToUnit(UN).ToString("a")
                                 .Replace(".", "*")
                                 .Replace("C", "K")
-                                .Replace("'°'F", "'\u00b0'R")
+                                .Replace("\u00b0F", "\u00b0R")
                                 .Replace('*', '\u00b7')
                                 );
 
@@ -900,7 +900,7 @@ public class Angle
                 Assert.AreEqual(
                     A2.ToUnit(EU).DisplaySymbol(),
                     A1.ToUnit(UN).ToString("a")
-                        .Replace("Ns", "N'\u00b7's")
+                        .Replace("Ns", "N\u00b7s")
                     );
 
                 WorkingCompares++;
@@ -1057,7 +1057,7 @@ public class Angle
                                 .Replace("day", "d")
                                 //.Replace("min", "m")
                                 .Replace("L", "l")
-                                .Replace("cy", "yd'\u00b3'")
+                                .Replace("cy", "yd\u00b3")
                                 .Replace("hr", "h")
                                 );
 
@@ -1261,7 +1261,7 @@ public class Angle
                 Assert.AreEqual(
                     A2.ToUnit(EU).DisplaySymbol(),
                     A1.ToUnit(UN).ToString("a")
-                        .Replace("'\u00b7'", "")
+                        .Replace("\u00b7", "")
                         );
 
                 WorkingCompares++;


### PR DESCRIPTION
continuation of #49 where I didn't catch the failing unit tests after pasting in the unicode characters with `''` inside the strings. Also, the degree symbol was automatically pasted as `°` instead of `\u00b0` in one location.