### PR TITLE
.Average() for Temperature fixed

### DIFF
--- a/EngineeringUnits/Extensions.cs
+++ b/EngineeringUnits/Extensions.cs
@@ -171,14 +171,6 @@ public static class Extensions
         return ((double)value).AddUnit<T>(UnitOfMeasure);
     }
 
-    // Overrides for temperature - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-    public static List<Temperature?> ToList(this (Temperature?, Temperature?) tuple) => [tuple.Item1, tuple.Item2];
-    public static List<Temperature?> ToList(this (Temperature?, Temperature?, Temperature?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3];
-    public static List<Temperature?> ToList(this (Temperature?, Temperature?, Temperature?, Temperature?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4];
-    public static List<Temperature?> ToList(this (Temperature?, Temperature?, Temperature?, Temperature?, Temperature?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5];
-    public static List<Temperature?> ToList(this (Temperature?, Temperature?, Temperature?, Temperature?, Temperature?, Temperature?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6];
-    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
     public static List<BaseUnit?> ToList(this (BaseUnit?, BaseUnit?) tuple) => [tuple.Item1, tuple.Item2];
     public static List<BaseUnit?> ToList(this (BaseUnit?, BaseUnit?, BaseUnit?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3];
     public static List<BaseUnit?> ToList(this (BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4];

--- a/EngineeringUnits/Extensions.cs
+++ b/EngineeringUnits/Extensions.cs
@@ -171,6 +171,14 @@ public static class Extensions
         return ((double)value).AddUnit<T>(UnitOfMeasure);
     }
 
+    // Overrides for temperature - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+    public static List<Temperature?> ToList(this (Temperature?, Temperature?) tuple) => [tuple.Item1, tuple.Item2];
+    public static List<Temperature?> ToList(this (Temperature?, Temperature?, Temperature?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3];
+    public static List<Temperature?> ToList(this (Temperature?, Temperature?, Temperature?, Temperature?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4];
+    public static List<Temperature?> ToList(this (Temperature?, Temperature?, Temperature?, Temperature?, Temperature?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5];
+    public static List<Temperature?> ToList(this (Temperature?, Temperature?, Temperature?, Temperature?, Temperature?, Temperature?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4, tuple.Item5, tuple.Item6];
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
     public static List<BaseUnit?> ToList(this (BaseUnit?, BaseUnit?) tuple) => [tuple.Item1, tuple.Item2];
     public static List<BaseUnit?> ToList(this (BaseUnit?, BaseUnit?, BaseUnit?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3];
     public static List<BaseUnit?> ToList(this (BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?) tuple) => [tuple.Item1, tuple.Item2, tuple.Item3, tuple.Item4];

--- a/EngineeringUnits/UnitMath.cs
+++ b/EngineeringUnits/UnitMath.cs
@@ -33,6 +33,29 @@ public static class UnitMath
     public static UnknownUnit? Sum(this (BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?) list) => list.ToList().Sum();
     public static UnknownUnit? Sum(this (BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?) list) => list.ToList().Sum();
 
+    // Average override for Temperature - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+    public static Temperature? Average(this IEnumerable<Temperature?> list)
+    {
+        if (list.Any() is false)
+            return null;
+
+        if (list.Any(x => x is null))
+            return null;
+
+        return Temperature.FromDegreeCelsius(
+            list.Select(v => v!.DegreeCelsius).Average()
+            );
+    }
+    public static Temperature? Average(params Temperature?[] x) => x.Average();
+    public static Temperature? Average(this (Temperature?, Temperature?) list) => list.ToList().Average();
+    public static Temperature? Average(this (Temperature?, Temperature?, Temperature?) list) => list.ToList().Average();
+    public static Temperature? Average(this (Temperature?, Temperature?, Temperature?, Temperature?) list) => list.ToList().Average();
+    public static Temperature? Average(this (Temperature?, Temperature?, Temperature?, Temperature?, Temperature?) list) => list.ToList().Average();
+    public static Temperature? Average(this (Temperature?, Temperature?, Temperature?, Temperature?, Temperature?, Temperature?) list) => list.ToList().Average();
+
+    // TODO: do we need the same for Sum() and others..?
+    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+
     /// <summary>
     /// Calculates the average value of a collection of <see cref="BaseUnit"/> objects.
     /// </summary>

--- a/EngineeringUnits/UnitMath.cs
+++ b/EngineeringUnits/UnitMath.cs
@@ -33,29 +33,6 @@ public static class UnitMath
     public static UnknownUnit? Sum(this (BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?) list) => list.ToList().Sum();
     public static UnknownUnit? Sum(this (BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?) list) => list.ToList().Sum();
 
-    // Average overrides for Temperature - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-    public static Temperature? Average(this IEnumerable<Temperature?> list)
-    {
-        if (list.Any() is false)
-            return null;
-
-        if (list.Any(x => x is null))
-            return null;
-
-        return Temperature.FromDegreeCelsius(
-            list.Select(v => v!.DegreeCelsius).Average()
-            );
-    }
-    public static Temperature? Average(params Temperature?[] x) => x.Average();
-    public static Temperature? Average(this (Temperature?, Temperature?) list) => list.ToList().Average();
-    public static Temperature? Average(this (Temperature?, Temperature?, Temperature?) list) => list.ToList().Average();
-    public static Temperature? Average(this (Temperature?, Temperature?, Temperature?, Temperature?) list) => list.ToList().Average();
-    public static Temperature? Average(this (Temperature?, Temperature?, Temperature?, Temperature?, Temperature?) list) => list.ToList().Average();
-    public static Temperature? Average(this (Temperature?, Temperature?, Temperature?, Temperature?, Temperature?, Temperature?) list) => list.ToList().Average();
-
-    // TODO: do we need the same for Sum() and others..?
-    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
-
     /// <summary>
     /// Calculates the average value of a collection of <see cref="BaseUnit"/> objects.
     /// </summary>

--- a/EngineeringUnits/UnitMath.cs
+++ b/EngineeringUnits/UnitMath.cs
@@ -33,7 +33,7 @@ public static class UnitMath
     public static UnknownUnit? Sum(this (BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?) list) => list.ToList().Sum();
     public static UnknownUnit? Sum(this (BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?, BaseUnit?) list) => list.ToList().Sum();
 
-    // Average override for Temperature - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+    // Average overrides for Temperature - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
     public static Temperature? Average(this IEnumerable<Temperature?> list)
     {
         if (list.Any() is false)

--- a/EngineeringUnits/UnitMath.cs
+++ b/EngineeringUnits/UnitMath.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using EngineeringUnits.Units;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -21,6 +22,13 @@ public static class UnitMath
 
         if (list.Any(x => x is null))
             return null;
+
+        // Fix for temperature, albeit not very elegant
+        if (list.All(u => u is Temperature))
+        {
+            return list.Aggregate(new UnknownUnit(0m, list.First()!.ToUnit(TemperatureUnit.SI)),
+                                (x, y) => (x + y)!);
+        }
 
         return list.Aggregate(new UnknownUnit(0m, list.First()!),
                             (x, y) => (x + y)!);

--- a/Sandbox/Program.cs
+++ b/Sandbox/Program.cs
@@ -1,5 +1,6 @@
 ﻿using EngineeringUnits;
 using EngineeringUnits.Units;
+using System;
 using System.Diagnostics;
 
 //using UnitsNet;
@@ -126,7 +127,7 @@ public class Program
 
         //var GToNon = G.ToUnit(PressureUnit.Bar);
 
-        _ = 10.1.AddUnit<PressureUnit>("test");
+        // _ = 10.1.AddUnit<PressureUnit>("test");
 
         //var test22 = AreaCostUnit.DollarPerSquareMillimeter;
 
@@ -705,6 +706,54 @@ public class Program
 
         //    Console.WriteLine(elapsedMs.ToString());
         //    _=Console.ReadLine();
+
+
+
+
+        // This tests the method used by the Aggregate function in UnitMath.Sum()
+        // (1) From Kelvin
+        var T1a = Temperature.FromKelvin(10);
+        var T1b = Temperature.FromKelvin(20);
+
+        // The Aggregate() method in Sum() does this:
+        var T1_UU = new UnknownUnit(0m, T1a) + T1a + T1b;
+
+        // This is correct if temperatures constructed from Kelvin
+        if (Temperature.FromKelvin(T1a.Kelvin + T1b.Kelvin) != (Temperature)T1_UU)
+        {
+            throw new Exception($"{Temperature.FromKelvin(T1a.Kelvin + T1b.Kelvin)} is not equal to {(Temperature)T1_UU}");
+        }
+
+        // (2) From Degrees C
+        var T2a = Temperature.FromDegreeCelsius(10);
+        var T2b = Temperature.FromDegreeCelsius(20);
+
+        // The Aggregate() method in Sum() currently does this
+        var T2_UU = new UnknownUnit(0m, T2a) + T2a + T2b;
+        if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU)
+        {
+            // This causes the original issue
+            // throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU}");
+        }
+
+        // For Temperature from DegreeCelsius, it should do this:
+        var T2_UU_fixedCelsius = new UnknownUnit(-273.15m, T2a) + T2a + T2b;
+        if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU_fixedCelsius)
+        {
+            throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU_fixedCelsius}");
+        }
+
+        // More generally, for all temperatues:
+        var T2_UU_fixedTemp1 = new UnknownUnit(Temperature.Zero) + T2a + T2b;
+        var T2_UU_fixedTemp2 = new UnknownUnit(0m, T2a.ToUnit(TemperatureUnit.SI)) + T2a + T2b;
+        if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU_fixedTemp1)
+        {
+            throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU_fixedTemp1}");
+        }
+        if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU_fixedTemp2)
+        {
+            throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU_fixedTemp2}");
+        }
 
     }
 

--- a/UnitTests/Math/UnitMathtest.cs
+++ b/UnitTests/Math/UnitMathtest.cs
@@ -117,7 +117,38 @@ public class UnitMathTest
     [TestMethod]
     public void Sum_Temperature() // TODO: this is testing [Sum()], Average(), Min() and Max()... should probably rename the test
     {
-        // NOTE: Sum() only makes sense when using Kelvin
+        // TEMP -----------------------------------------------------------------------------
+            // This tests the method used by the Aggregate function in UnitMath.Sum()
+            // (1) From Kelvin
+            var T1a = Temperature.FromKelvin(10);
+            var T1b = Temperature.FromKelvin(20);
+
+            // The Aggregate() method in Sum() does this:
+            var T1_UU = new UnknownUnit(0m, T1a) + T1a + T1b;
+
+            // This is correct if temperatures constructed from Kelvin
+            Assert.AreEqual(Temperature.FromKelvin(T1a.Kelvin + T1b.Kelvin), (Temperature)T1_UU);
+
+
+            // (2) From Degrees C
+            var T2a = Temperature.FromDegreeCelsius(10);
+            var T2b = Temperature.FromDegreeCelsius(20);
+
+            // The Aggregate() method in Sum() currently does this (causes error)
+            var T2_UU = new UnknownUnit(0m, T2a) + T2a + T2b;
+            // Assert.AreEqual(Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin), (Temperature)T2_UU);
+
+            // For Temperature from DegreeCelsius, it should do this:
+            var T2_UU_fixedCelsius = new UnknownUnit(-273.15m, T2a) + T2a + T2b;
+            Assert.AreEqual(Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin), (Temperature)T2_UU_fixedCelsius);
+
+            // More generally, for all temperatues:
+            var T2_UU_fixedTemp1 = new UnknownUnit(Temperature.Zero) + T2a + T2b;
+            var T2_UU_fixedTemp2 = new UnknownUnit(0m, T2a.ToUnit(TemperatureUnit.SI)) + T2a + T2b;
+            Assert.AreEqual(Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin), (Temperature)T2_UU_fixedTemp1);
+            Assert.AreEqual(Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin), (Temperature)T2_UU_fixedTemp2);
+
+        // TEMP -----------------------------------------------------------------------------
         //       Average(), Min() and Max(), also make sense for "relative" DegreesCelsius etc
 
         var list1 = new List<Temperature>

--- a/UnitTests/Math/UnitMathtest.cs
+++ b/UnitTests/Math/UnitMathtest.cs
@@ -117,39 +117,6 @@ public class UnitMathTest
     [TestMethod]
     public void Sum_Temperature() // TODO: this is testing [Sum()], Average(), Min() and Max()... should probably rename the test
     {
-        // TEMP -----------------------------------------------------------------------------
-            // This tests the method used by the Aggregate function in UnitMath.Sum()
-            // (1) From Kelvin
-            var T1a = Temperature.FromKelvin(10);
-            var T1b = Temperature.FromKelvin(20);
-
-            // The Aggregate() method in Sum() does this:
-            var T1_UU = new UnknownUnit(0m, T1a) + T1a + T1b;
-
-            // This is correct if temperatures constructed from Kelvin
-            Assert.AreEqual(Temperature.FromKelvin(T1a.Kelvin + T1b.Kelvin), (Temperature)T1_UU);
-
-
-            // (2) From Degrees C
-            var T2a = Temperature.FromDegreeCelsius(10);
-            var T2b = Temperature.FromDegreeCelsius(20);
-
-            // The Aggregate() method in Sum() currently does this (causes error)
-            var T2_UU = new UnknownUnit(0m, T2a) + T2a + T2b;
-            // Assert.AreEqual(Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin), (Temperature)T2_UU);
-
-            // For Temperature from DegreeCelsius, it should do this:
-            var T2_UU_fixedCelsius = new UnknownUnit(-273.15m, T2a) + T2a + T2b;
-            Assert.AreEqual(Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin), (Temperature)T2_UU_fixedCelsius);
-
-            // More generally, for all temperatues:
-            var T2_UU_fixedTemp1 = new UnknownUnit(Temperature.Zero) + T2a + T2b;
-            var T2_UU_fixedTemp2 = new UnknownUnit(0m, T2a.ToUnit(TemperatureUnit.SI)) + T2a + T2b;
-            Assert.AreEqual(Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin), (Temperature)T2_UU_fixedTemp1);
-            Assert.AreEqual(Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin), (Temperature)T2_UU_fixedTemp2);
-
-        // TEMP -----------------------------------------------------------------------------
-
         // Kelvin
         var list1K = new List<Temperature>
         {

--- a/UnitTests/Math/UnitMathtest.cs
+++ b/UnitTests/Math/UnitMathtest.cs
@@ -523,10 +523,10 @@ public class UnitMathTest
         Assert.IsNotNull(averageDegC4);
         Assert.IsNotNull(averageDegC5);
 
-        Assert.AreEqual(Temperature.FromDegreeCelsius(1.5), averageDegC2);
-        Assert.AreEqual(Temperature.FromDegreeCelsius(2.0), averageDegC3);
-        Assert.AreEqual(Temperature.FromDegreeCelsius(2.5), averageDegC4);
-        Assert.AreEqual(Temperature.FromDegreeCelsius(3.0), averageDegC5);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(1.5), (Temperature)averageDegC2);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(2.0), (Temperature)averageDegC3);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(2.5), (Temperature)averageDegC4);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(3.0), (Temperature)averageDegC5);
 
         // Testing Kelvin
         var averageK2 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2)).Average();
@@ -539,10 +539,10 @@ public class UnitMathTest
         Assert.IsNotNull(averageK4);
         Assert.IsNotNull(averageK5);
 
-        Assert.AreEqual(Temperature.FromKelvin(1.5), averageK2);
-        Assert.AreEqual(Temperature.FromKelvin(2.0), averageK3);
-        Assert.AreEqual(Temperature.FromKelvin(2.5), averageK4);
-        Assert.AreEqual(Temperature.FromKelvin(3.0), averageK5);
+        Assert.AreEqual(Temperature.FromKelvin(1.5), (Temperature)averageK2);
+        Assert.AreEqual(Temperature.FromKelvin(2.0), (Temperature)averageK3);
+        Assert.AreEqual(Temperature.FromKelvin(2.5), (Temperature)averageK4);
+        Assert.AreEqual(Temperature.FromKelvin(3.0), (Temperature)averageK5);
     }
 
     [TestMethod]

--- a/UnitTests/Math/UnitMathtest.cs
+++ b/UnitTests/Math/UnitMathtest.cs
@@ -372,6 +372,43 @@ public class UnitMathTest
         Assert.AreEqual(Frequency.FromHertz(2.5), (Frequency)average4);
         Assert.AreEqual(Frequency.FromHertz(3), (Frequency)average5);
     }
+
+    [TestMethod]
+    public void Average_Temperature()
+    {
+        // Testing DegreeCelsius
+        UnknownUnit? averageDegC2 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2)).Average();
+        UnknownUnit? averageDegC3 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2), Temperature.FromDegreeCelsius(3)).Average();
+        UnknownUnit? averageDegC4 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2), Temperature.FromDegreeCelsius(3), Temperature.FromDegreeCelsius(4)).Average();
+        UnknownUnit? averageDegC5 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2), Temperature.FromDegreeCelsius(3), Temperature.FromDegreeCelsius(4), Temperature.FromDegreeCelsius(5)).Average();
+
+        Assert.IsNotNull(averageDegC2);
+        Assert.IsNotNull(averageDegC3);
+        Assert.IsNotNull(averageDegC4);
+        Assert.IsNotNull(averageDegC5);
+
+        Assert.AreEqual(Temperature.FromDegreeCelsius(1.5), (Temperature)averageDegC2);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(2.0), (Temperature)averageDegC3);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(2.5), (Temperature)averageDegC4);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(3.0), (Temperature)averageDegC5);
+
+        // Testing Kelvin
+        UnknownUnit? averageK2 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2)).Average();
+        UnknownUnit? averageK3 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2), Temperature.FromKelvin(3)).Average();
+        UnknownUnit? averageK4 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2), Temperature.FromKelvin(3), Temperature.FromKelvin(4)).Average();
+        UnknownUnit? averageK5 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2), Temperature.FromKelvin(3), Temperature.FromKelvin(4), Temperature.FromKelvin(5)).Average();
+
+        Assert.IsNotNull(averageK2);
+        Assert.IsNotNull(averageK3);
+        Assert.IsNotNull(averageK4);
+        Assert.IsNotNull(averageK5);
+
+        Assert.AreEqual(Temperature.FromKelvin(1.5), (Temperature)averageK2);
+        Assert.AreEqual(Temperature.FromKelvin(2.0), (Temperature)averageK3);
+        Assert.AreEqual(Temperature.FromKelvin(2.5), (Temperature)averageK4);
+        Assert.AreEqual(Temperature.FromKelvin(3.0), (Temperature)averageK5);
+    }
+
     [TestMethod]
     public void Mean()
     {

--- a/UnitTests/Math/UnitMathtest.cs
+++ b/UnitTests/Math/UnitMathtest.cs
@@ -112,6 +112,111 @@ public class UnitMathTest
         Assert.AreEqual(Min, Min3);
 
     }
+    
+
+    [TestMethod]
+    public void Sum_Temperature() // TODO: this is testing [Sum()], Average(), Min() and Max()... should probably rename the test
+    {
+        // NOTE: Sum() only makes sense when using Kelvin
+        //       Average(), Min() and Max(), also make sense for "relative" DegreesCelsius etc
+
+        var list1 = new List<Temperature>
+        {
+            Temperature.FromKelvin(2),
+            Temperature.FromKelvin(1),
+            Temperature.FromKelvin(3),
+            Temperature.FromKelvin(4),
+            Temperature.FromKelvin(5),
+            Temperature.FromKelvin(6),
+            Temperature.FromKelvin(7),
+            Temperature.FromKelvin(8),
+            Temperature.FromKelvin(10),
+            Temperature.FromKelvin(9),
+        };
+
+        Temperature? Average = UnitMath.Average(list1);
+        Temperature? Sum = UnitMath.Sum(list1);
+        Temperature? Max = UnitMath.Max(list1);
+        Temperature? Min = UnitMath.Min(list1);
+
+        Temperature? Average2 = UnitMath.Average(
+            Temperature.FromKelvin(1),
+            Temperature.FromKelvin(2),
+            Temperature.FromKelvin(3),
+            Temperature.FromKelvin(4),
+            Temperature.FromKelvin(5),
+            Temperature.FromKelvin(6),
+            Temperature.FromKelvin(7),
+            Temperature.FromKelvin(8),
+            Temperature.FromKelvin(9),
+            Temperature.FromKelvin(10)
+            );
+
+        Temperature? Sum2 = UnitMath.Sum( // NOTE: Sum() only makes sense when using Kelvin
+            Temperature.FromKelvin(1),
+            Temperature.FromKelvin(2),
+            Temperature.FromKelvin(3),
+            Temperature.FromKelvin(4),
+            Temperature.FromKelvin(5),
+            Temperature.FromKelvin(6),
+            Temperature.FromKelvin(7),
+            Temperature.FromKelvin(8),
+            Temperature.FromKelvin(9),
+            Temperature.FromKelvin(10)
+            );
+
+        Temperature? Max2 = UnitMath.Max(
+            Temperature.FromKelvin(1),
+            Temperature.FromKelvin(2),
+            Temperature.FromKelvin(3),
+            Temperature.FromKelvin(4),
+            Temperature.FromKelvin(5),
+            Temperature.FromKelvin(6),
+            Temperature.FromKelvin(7),
+            Temperature.FromKelvin(8),
+            Temperature.FromKelvin(9),
+            Temperature.FromKelvin(10)
+            );
+
+        Temperature? Min2 = UnitMath.Min(
+                Temperature.FromKelvin(1),
+                Temperature.FromKelvin(2),
+                Temperature.FromKelvin(3),
+                Temperature.FromKelvin(4),
+                Temperature.FromKelvin(5),
+                Temperature.FromKelvin(6),
+                Temperature.FromKelvin(7),
+                Temperature.FromKelvin(8),
+                Temperature.FromKelvin(9),
+                Temperature.FromKelvin(10)
+                );
+
+        Temperature? Average3 = list1.Average();
+        Temperature? Sum3 = list1.Sum();
+        Temperature? Max3 = list1.Max();
+        Temperature? Min3 = list1.Min();
+
+        Assert.IsNotNull(Average);
+        Assert.IsNotNull(Sum);
+        Assert.IsNotNull(Max);
+        Assert.IsNotNull(Min);
+
+        Assert.AreEqual(Average.Kelvin, 5.5, 0);
+        Assert.AreEqual(Sum.Kelvin, 55, 0); // NOTE: Sum() only makes sense when using Kelvin
+        Assert.AreEqual(Max.Kelvin, 10, 0);
+        Assert.AreEqual(Min.Kelvin, 1, 0);
+
+        Assert.AreEqual(Average, Average2);
+        Assert.AreEqual(Sum, Sum2);
+        Assert.AreEqual(Max, Max2);
+        Assert.AreEqual(Min, Min2);
+
+        Assert.AreEqual(Average, Average3);
+        Assert.AreEqual(Sum, Sum3);
+        Assert.AreEqual(Max, Max3);
+        Assert.AreEqual(Min, Min3);
+
+    }
 
     //Create test
 

--- a/UnitTests/Math/UnitMathtest.cs
+++ b/UnitTests/Math/UnitMathtest.cs
@@ -252,7 +252,7 @@ public class UnitMathTest
             Length.FromKilometer(1)/Duration.FromHour(1),
             Length.FromKilometer(1)/Duration.FromHour(3),
             Length.FromKilometer(1)/Duration.FromHour(5),
-             Length.FromKilometer(1)/Duration.FromHour(4)
+            Length.FromKilometer(1)/Duration.FromHour(4)
 
         };
 
@@ -262,7 +262,7 @@ public class UnitMathTest
         UnknownUnit? Min = UnitMath.Min(list1);
 
         UnknownUnit? Average2 = UnitMath.Average(
-       Length.FromKilometer(1) / Duration.FromHour(1),
+        Length.FromKilometer(1) / Duration.FromHour(1),
         Length.FromKilometer(1) / Duration.FromHour(2),
         Length.FromKilometer(1) / Duration.FromHour(3),
         Length.FromKilometer(1) / Duration.FromHour(4),
@@ -270,7 +270,7 @@ public class UnitMathTest
         );
 
         UnknownUnit? Sum2 = UnitMath.Sum(
-           Length.FromKilometer(1) / Duration.FromHour(1),
+            Length.FromKilometer(1) / Duration.FromHour(1),
             Length.FromKilometer(1) / Duration.FromHour(2),
             Length.FromKilometer(1) / Duration.FromHour(3),
             Length.FromKilometer(1) / Duration.FromHour(4),

--- a/UnitTests/Math/UnitMathtest.cs
+++ b/UnitTests/Math/UnitMathtest.cs
@@ -12,7 +12,7 @@ public class UnitMathTest
 {
 
     [TestMethod]
-    public void Sum()
+    public void Sum() // TODO: this is testing Sum(), Average(), Min() and Max()... should probably rename the test
     {
 
         var list1 = new List<MassFlow>

--- a/UnitTests/Math/UnitMathtest.cs
+++ b/UnitTests/Math/UnitMathtest.cs
@@ -377,36 +377,36 @@ public class UnitMathTest
     public void Average_Temperature()
     {
         // Testing DegreeCelsius
-        UnknownUnit? averageDegC2 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2)).Average();
-        UnknownUnit? averageDegC3 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2), Temperature.FromDegreeCelsius(3)).Average();
-        UnknownUnit? averageDegC4 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2), Temperature.FromDegreeCelsius(3), Temperature.FromDegreeCelsius(4)).Average();
-        UnknownUnit? averageDegC5 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2), Temperature.FromDegreeCelsius(3), Temperature.FromDegreeCelsius(4), Temperature.FromDegreeCelsius(5)).Average();
+        var averageDegC2 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2)).Average();
+        var averageDegC3 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2), Temperature.FromDegreeCelsius(3)).Average();
+        var averageDegC4 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2), Temperature.FromDegreeCelsius(3), Temperature.FromDegreeCelsius(4)).Average();
+        var averageDegC5 = (Temperature.FromDegreeCelsius(1), Temperature.FromDegreeCelsius(2), Temperature.FromDegreeCelsius(3), Temperature.FromDegreeCelsius(4), Temperature.FromDegreeCelsius(5)).Average();
 
         Assert.IsNotNull(averageDegC2);
         Assert.IsNotNull(averageDegC3);
         Assert.IsNotNull(averageDegC4);
         Assert.IsNotNull(averageDegC5);
 
-        Assert.AreEqual(Temperature.FromDegreeCelsius(1.5), (Temperature)averageDegC2);
-        Assert.AreEqual(Temperature.FromDegreeCelsius(2.0), (Temperature)averageDegC3);
-        Assert.AreEqual(Temperature.FromDegreeCelsius(2.5), (Temperature)averageDegC4);
-        Assert.AreEqual(Temperature.FromDegreeCelsius(3.0), (Temperature)averageDegC5);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(1.5), averageDegC2);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(2.0), averageDegC3);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(2.5), averageDegC4);
+        Assert.AreEqual(Temperature.FromDegreeCelsius(3.0), averageDegC5);
 
         // Testing Kelvin
-        UnknownUnit? averageK2 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2)).Average();
-        UnknownUnit? averageK3 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2), Temperature.FromKelvin(3)).Average();
-        UnknownUnit? averageK4 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2), Temperature.FromKelvin(3), Temperature.FromKelvin(4)).Average();
-        UnknownUnit? averageK5 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2), Temperature.FromKelvin(3), Temperature.FromKelvin(4), Temperature.FromKelvin(5)).Average();
+        var averageK2 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2)).Average();
+        var averageK3 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2), Temperature.FromKelvin(3)).Average();
+        var averageK4 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2), Temperature.FromKelvin(3), Temperature.FromKelvin(4)).Average();
+        var averageK5 = (Temperature.FromKelvin(1), Temperature.FromKelvin(2), Temperature.FromKelvin(3), Temperature.FromKelvin(4), Temperature.FromKelvin(5)).Average();
 
         Assert.IsNotNull(averageK2);
         Assert.IsNotNull(averageK3);
         Assert.IsNotNull(averageK4);
         Assert.IsNotNull(averageK5);
 
-        Assert.AreEqual(Temperature.FromKelvin(1.5), (Temperature)averageK2);
-        Assert.AreEqual(Temperature.FromKelvin(2.0), (Temperature)averageK3);
-        Assert.AreEqual(Temperature.FromKelvin(2.5), (Temperature)averageK4);
-        Assert.AreEqual(Temperature.FromKelvin(3.0), (Temperature)averageK5);
+        Assert.AreEqual(Temperature.FromKelvin(1.5), averageK2);
+        Assert.AreEqual(Temperature.FromKelvin(2.0), averageK3);
+        Assert.AreEqual(Temperature.FromKelvin(2.5), averageK4);
+        Assert.AreEqual(Temperature.FromKelvin(3.0), averageK5);
     }
 
     [TestMethod]

--- a/UnitTests/Math/UnitMathtest.cs
+++ b/UnitTests/Math/UnitMathtest.cs
@@ -149,9 +149,9 @@ public class UnitMathTest
             Assert.AreEqual(Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin), (Temperature)T2_UU_fixedTemp2);
 
         // TEMP -----------------------------------------------------------------------------
-        //       Average(), Min() and Max(), also make sense for "relative" DegreesCelsius etc
 
-        var list1 = new List<Temperature>
+        // Kelvin
+        var list1K = new List<Temperature>
         {
             Temperature.FromKelvin(2),
             Temperature.FromKelvin(1),
@@ -165,12 +165,12 @@ public class UnitMathTest
             Temperature.FromKelvin(9),
         };
 
-        Temperature? Average = UnitMath.Average(list1);
-        Temperature? Sum = UnitMath.Sum(list1);
-        Temperature? Max = UnitMath.Max(list1);
-        Temperature? Min = UnitMath.Min(list1);
+        Temperature? AverageK = UnitMath.Average(list1K);
+        Temperature? SumK =     UnitMath.Sum(list1K);
+        Temperature? MaxK =     UnitMath.Max(list1K);
+        Temperature? MinK =     UnitMath.Min(list1K);
 
-        Temperature? Average2 = UnitMath.Average(
+        Temperature? Average2K = UnitMath.Average(
             Temperature.FromKelvin(1),
             Temperature.FromKelvin(2),
             Temperature.FromKelvin(3),
@@ -183,7 +183,7 @@ public class UnitMathTest
             Temperature.FromKelvin(10)
             );
 
-        Temperature? Sum2 = UnitMath.Sum( // NOTE: Sum() only makes sense when using Kelvin
+        Temperature? Sum2K = UnitMath.Sum(
             Temperature.FromKelvin(1),
             Temperature.FromKelvin(2),
             Temperature.FromKelvin(3),
@@ -196,7 +196,7 @@ public class UnitMathTest
             Temperature.FromKelvin(10)
             );
 
-        Temperature? Max2 = UnitMath.Max(
+        Temperature? Max2K = UnitMath.Max(
             Temperature.FromKelvin(1),
             Temperature.FromKelvin(2),
             Temperature.FromKelvin(3),
@@ -209,44 +209,141 @@ public class UnitMathTest
             Temperature.FromKelvin(10)
             );
 
-        Temperature? Min2 = UnitMath.Min(
-                Temperature.FromKelvin(1),
-                Temperature.FromKelvin(2),
-                Temperature.FromKelvin(3),
-                Temperature.FromKelvin(4),
-                Temperature.FromKelvin(5),
-                Temperature.FromKelvin(6),
-                Temperature.FromKelvin(7),
-                Temperature.FromKelvin(8),
-                Temperature.FromKelvin(9),
-                Temperature.FromKelvin(10)
-                );
+        Temperature? Min2K = UnitMath.Min(
+            Temperature.FromKelvin(1),
+            Temperature.FromKelvin(2),
+            Temperature.FromKelvin(3),
+            Temperature.FromKelvin(4),
+            Temperature.FromKelvin(5),
+            Temperature.FromKelvin(6),
+            Temperature.FromKelvin(7),
+            Temperature.FromKelvin(8),
+            Temperature.FromKelvin(9),
+            Temperature.FromKelvin(10)
+            );
 
-        Temperature? Average3 = list1.Average();
-        Temperature? Sum3 = list1.Sum();
-        Temperature? Max3 = list1.Max();
-        Temperature? Min3 = list1.Min();
+        Temperature? Average3K = list1K.Average();
+        Temperature? Sum3K = list1K.Sum();
+        Temperature? Max3K = list1K.Max();
+        Temperature? Min3K = list1K.Min();
 
-        Assert.IsNotNull(Average);
-        Assert.IsNotNull(Sum);
-        Assert.IsNotNull(Max);
-        Assert.IsNotNull(Min);
+        Assert.IsNotNull(AverageK);
+        Assert.IsNotNull(SumK);
+        Assert.IsNotNull(MaxK);
+        Assert.IsNotNull(MinK);
 
-        Assert.AreEqual(Average.Kelvin, 5.5, 0);
-        Assert.AreEqual(Sum.Kelvin, 55, 0); // NOTE: Sum() only makes sense when using Kelvin
-        Assert.AreEqual(Max.Kelvin, 10, 0);
-        Assert.AreEqual(Min.Kelvin, 1, 0);
+        Assert.AreEqual(AverageK.Kelvin, 5.5, 0);
+        Assert.AreEqual(SumK.Kelvin, 55, 0);
+        Assert.AreEqual(MaxK.Kelvin, 10, 0);
+        Assert.AreEqual(MinK.Kelvin, 1, 0);
 
-        Assert.AreEqual(Average, Average2);
-        Assert.AreEqual(Sum, Sum2);
-        Assert.AreEqual(Max, Max2);
-        Assert.AreEqual(Min, Min2);
+        Assert.AreEqual(AverageK, Average2K);
+        Assert.AreEqual(SumK, Sum2K);
+        Assert.AreEqual(MaxK, Max2K);
+        Assert.AreEqual(MinK, Min2K);
 
-        Assert.AreEqual(Average, Average3);
-        Assert.AreEqual(Sum, Sum3);
-        Assert.AreEqual(Max, Max3);
-        Assert.AreEqual(Min, Min3);
+        Assert.AreEqual(AverageK, Average3K);
+        Assert.AreEqual(SumK, Sum3K);
+        Assert.AreEqual(MaxK, Max3K);
+        Assert.AreEqual(MinK, Min3K);
 
+
+        // DegreesCelsius
+        var list1C = new List<Temperature>
+        {
+            Temperature.FromDegreeCelsius(2),
+            Temperature.FromDegreeCelsius(1),
+            Temperature.FromDegreeCelsius(3),
+            Temperature.FromDegreeCelsius(4),
+            Temperature.FromDegreeCelsius(5),
+            Temperature.FromDegreeCelsius(6),
+            Temperature.FromDegreeCelsius(7),
+            Temperature.FromDegreeCelsius(8),
+            Temperature.FromDegreeCelsius(10),
+            Temperature.FromDegreeCelsius(9),
+        };
+
+        Temperature? AverageC = UnitMath.Average(list1C);
+        Temperature? SumC =     UnitMath.Sum(list1C);
+        Temperature? MaxC =     UnitMath.Max(list1C);
+        Temperature? MinC =     UnitMath.Min(list1C);
+
+        Temperature? Average2C = UnitMath.Average(
+            Temperature.FromDegreeCelsius(1),
+            Temperature.FromDegreeCelsius(2),
+            Temperature.FromDegreeCelsius(3),
+            Temperature.FromDegreeCelsius(4),
+            Temperature.FromDegreeCelsius(5),
+            Temperature.FromDegreeCelsius(6),
+            Temperature.FromDegreeCelsius(7),
+            Temperature.FromDegreeCelsius(8),
+            Temperature.FromDegreeCelsius(9),
+            Temperature.FromDegreeCelsius(10)
+            );
+
+        Temperature? Sum2C = UnitMath.Sum(
+            Temperature.FromDegreeCelsius(1),
+            Temperature.FromDegreeCelsius(2),
+            Temperature.FromDegreeCelsius(3),
+            Temperature.FromDegreeCelsius(4),
+            Temperature.FromDegreeCelsius(5),
+            Temperature.FromDegreeCelsius(6),
+            Temperature.FromDegreeCelsius(7),
+            Temperature.FromDegreeCelsius(8),
+            Temperature.FromDegreeCelsius(9),
+            Temperature.FromDegreeCelsius(10)
+            );
+
+        Temperature? Max2C = UnitMath.Max(
+            Temperature.FromDegreeCelsius(1),
+            Temperature.FromDegreeCelsius(2),
+            Temperature.FromDegreeCelsius(3),
+            Temperature.FromDegreeCelsius(4),
+            Temperature.FromDegreeCelsius(5),
+            Temperature.FromDegreeCelsius(6),
+            Temperature.FromDegreeCelsius(7),
+            Temperature.FromDegreeCelsius(8),
+            Temperature.FromDegreeCelsius(9),
+            Temperature.FromDegreeCelsius(10)
+            );
+
+        Temperature? Min2C = UnitMath.Min(
+            Temperature.FromDegreeCelsius(1),
+            Temperature.FromDegreeCelsius(2),
+            Temperature.FromDegreeCelsius(3),
+            Temperature.FromDegreeCelsius(4),
+            Temperature.FromDegreeCelsius(5),
+            Temperature.FromDegreeCelsius(6),
+            Temperature.FromDegreeCelsius(7),
+            Temperature.FromDegreeCelsius(8),
+            Temperature.FromDegreeCelsius(9),
+            Temperature.FromDegreeCelsius(10)
+            );
+
+        Temperature? Average3C = list1C.Average();
+        Temperature? Sum3C = list1C.Sum();
+        Temperature? Max3C = list1C.Max();
+        Temperature? Min3C = list1C.Min();
+
+        Assert.IsNotNull(AverageC);
+        Assert.IsNotNull(SumC);
+        Assert.IsNotNull(MaxC);
+        Assert.IsNotNull(MinC);
+
+        Assert.AreEqual(AverageC.DegreeCelsius, 5.5, 0);
+        Assert.AreEqual(SumC.DegreeCelsius, 2513.35, 0); // This is a little weird but I guess correct..
+        Assert.AreEqual(MaxC.DegreeCelsius, 10, 0);
+        Assert.AreEqual(MinC.DegreeCelsius, 1, 0);
+
+        Assert.AreEqual(AverageC, Average2C);
+        Assert.AreEqual(SumC, Sum2C);
+        Assert.AreEqual(MaxC, Max2C);
+        Assert.AreEqual(MinC, Min2C);
+
+        Assert.AreEqual(AverageC, Average3C);
+        Assert.AreEqual(SumC, Sum3C);
+        Assert.AreEqual(MaxC, Max3C);
+        Assert.AreEqual(MinC, Min3C);
     }
 
     //Create test


### PR DESCRIPTION
The issue comes from `Sum()`, which only makes sense for absolute temperature (Kelvin).

The added `Average()` methods also work for relative temperatures, e.g. °C.

Maybe there is a "cleaner" fix for this... like replacing the current `return list.Sum() / list.Count();` in the generic `Average` method by something that does the right thing in case of `Temperature`.