### PR TITLE
Fixing error in conversion between USDollar and MillionUSDollar

### DIFF
--- a/EngineeringUnits/BaseUnits/Cost/CostEnum.cs
+++ b/EngineeringUnits/BaseUnits/Cost/CostEnum.cs
@@ -8,7 +8,7 @@ public partial record CostUnit : UnitTypebase
 {
     public static readonly CostUnit SI = new CostUnit("USD", "$", GetRate(Currency.USDollar));
     public static readonly CostUnit USDollar = new CostUnit("USD", "$", GetRate(Currency.USDollar));
-    public static readonly CostUnit MillionUSDollar = new CostUnit("USD", "M$", GetRate(Currency.USDollar)/1000000m);
+    public static readonly CostUnit MillionUSDollar = new CostUnit("USD", "M$", GetRate(Currency.USDollar) * 1000000m);
 
     public static readonly CostUnit Euro = new CostUnit("Euro", "€", GetRate(Currency.Euro));
     public static readonly CostUnit BritishPound = new CostUnit("GBP", "£", GetRate(Currency.BritishPound));

--- a/EngineeringUnits/BaseUnits/Cost/CostEnum.cs
+++ b/EngineeringUnits/BaseUnits/Cost/CostEnum.cs
@@ -18,7 +18,7 @@ public partial record CostUnit : UnitTypebase
     {
         var unit = new RawUnit()
         {
-            Symbol=Symbol,
+            Symbol = Symbol,
             A = (Fraction)Rate,
             UnitType = BaseunitType.Cost,
             B = 0,

--- a/UnitTests/CostTests.cs
+++ b/UnitTests/CostTests.cs
@@ -28,6 +28,17 @@ public class CostTests
     }
 
     [TestMethod()]
+    public void CostMillionDollar()
+    {
+        //Arrange
+        var test1 = new Cost(1, CostUnit.MillionUSDollar);
+        var test2 = new Cost(1e6, CostUnit.USDollar);
+
+        // Assert
+        Assert.AreEqual(test1.USDollar, test2.USDollar);
+    }
+
+    [TestMethod()]
     public void CostEuro()
     {
         //Arrange


### PR DESCRIPTION
... value needs to be multiplied instead of divided by 1'000'000.