### PR TITLE
Adding rounding extensions

### DIFF
--- a/EngineeringUnits/BaseUnitExtensions.cs
+++ b/EngineeringUnits/BaseUnitExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using Fractions;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -424,5 +423,51 @@ public static class BaseUnitExtensions
         return new(value, unitsystem);
     }
 
+    /// <summary>
+    /// Round a <paramref name="value"/> to the nearest <paramref name="roundVal"/>
+    /// </summary>
+    /// <param name="value">Value to round</param>
+    /// <param name="roundVal"></param>
+    [return: NotNullIfNotNull(nameof(value))]
+    public static UnknownUnit? RoundTo<T>(this T? value, T? roundVal) where T : BaseUnit
+    {
+        if (value is null)
+            return null;
+        if (roundVal is null)
+            return new(value);
 
+        return Math.Round((double)(Ratio)(value / roundVal)) * roundVal;
+    }
+
+    /// <summary>
+    /// Round a <paramref name="value"/> up to the nearest <paramref name="roundVal"/>
+    /// </summary>
+    /// <param name="value">Value to round</param>
+    /// <param name="roundVal"></param>
+    [return: NotNullIfNotNull(nameof(value))]
+    public static UnknownUnit? CeilingTo<T>(this T? value, T? roundVal) where T : BaseUnit
+    {
+        if (value is null)
+            return null;
+        if (roundVal is null)
+            return new(value);
+
+        return Math.Ceiling((double)(Ratio)(value / roundVal)) * roundVal;
+    }
+
+    /// <summary>
+    /// Round a <paramref name="value"/> down to the nearest <paramref name="roundVal"/>
+    /// </summary>
+    /// <param name="value">Value to round</param>
+    /// <param name="roundVal"></param>
+    [return: NotNullIfNotNull(nameof(value))]
+    public static UnknownUnit? FloorTo<T>(this T? value, T? roundVal) where T : BaseUnit
+    {
+        if (value is null)
+            return null;
+        if (roundVal is null)
+            return new(value);
+
+        return Math.Floor((double)(Ratio)(value / roundVal)) * roundVal;
+    }
 }

--- a/UnitTests/Extensiontest.cs
+++ b/UnitTests/Extensiontest.cs
@@ -124,4 +124,15 @@ public class Extensiontest
         Assert.IsNotNull(Sum);
         Assert.AreEqual("1 m", Sum.ToString("G5"));
     }
+
+    [TestMethod]
+    public void Rounding()
+    {
+        Volume v0 = Volume.FromCubicMeter(95.0);
+
+        Assert.AreEqual((Volume)v0.CeilingTo(Volume.FromCubicMeter(10)), Volume.FromCubicMeter(100));
+        Assert.AreEqual((Volume)v0.RoundTo(  Volume.FromCubicMeter(10)), Volume.FromCubicMeter(100));
+        Assert.AreEqual((Volume)v0.FloorTo(  Volume.FromCubicMeter(10)), Volume.FromCubicMeter( 90));
+
+    }
 }


### PR DESCRIPTION
@MadsKirkFoged let me know what you think about the implementation and naming of this. It's just something I needed a few times in a project so I though I'd add it to the library.

I chose to implement this using generic methods with `T : BaseUnit`, e.g.

```csharp
public static UnknownUnit? RoundTo<T>(this T? value, T? roundVal) where T : BaseUnit
```

... so a user is forced to use the same Unit for `value` and `roundValue`, i.e. you can't round a `Volume` to a `Mass` etc. Alternatively, one could implement it like 

```csharp
public static UnknownUnit? RoundTo(this BaseUnit? value, BaseUnit? roundVal)
```

and rely on the runtime checks in `Ratio` to throw an exception.