### PR TITLE
Target framework updates

### DIFF
--- a/Sandbox/Sandbox.csproj
+++ b/Sandbox/Sandbox.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>12.0</LangVersion>
 	  <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFrameworks>net470;net6.0;net8.0</TargetFrameworks>
+	  <TargetFrameworks>net472;net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>preview</LangVersion>
 	  <Nullable>enable</Nullable>


### PR DESCRIPTION
1. might as well use .NET8 for Sandbox, since we use it for CodeGen and Benchmark

1. `net470` isn't really a thing I think, see https://learn.microsoft.com/en-us/dotnet/standard/frameworks. `net47` would be the correct way for .NET Framework 4.7.0. I think it was kind of interpreted correctly but I did see some weird behavior in Visual Studio's test window where tests showed up for both "net47" and "net470"... anyway thought we might as well go to 4.7.2 with `net472`. Guess one could also do `net481`.