### PR TITLE
Add new unit Snap

### DIFF
--- a/CodeGen/Code/ExtensionGenerator.cs
+++ b/CodeGen/Code/ExtensionGenerator.cs
@@ -54,40 +54,39 @@ namespace CodeGen
                    using System;
                    using System.Diagnostics.CodeAnalysis;
 
-                   namespace EngineeringUnits
-                   {                   
-                       // This class is auto-generated, changes to the file will be overwritten!
-                       public static class VariableUnitExtension
+                   namespace EngineeringUnits;
+                   
+                   // This class is auto-generated, changes to the file will be overwritten!
+                   public static class VariableUnitExtension
+                   {
+
+                       public static Variable IfNullSetToZero(this Variable? local)
                        {
-
-                           public static Variable IfNullSetToZero(this Variable? local)
+                           if (local is not null)
                            {
-                               if (local is not null)
-                               {
-                                   return local;
-                               }
-
-                               return Variable.Zero;
+                               return local;
                            }
 
-
-                           /// <summary>
-                           /// Returns the absolute value
-                           /// </summary>
-                           [return: NotNullIfNotNull(nameof(a))]
-                           public static Variable? Abs(this Variable? a)
-                           {
-                               if (a is null)
-                                   return null;
-
-                               if (a.GetBaseValue() > 0)
-                                   return a;
-
-                               return (-a)!;
-                           }
-
+                           return Variable.Zero;
                        }
-                   }                   
+
+
+                       /// <summary>
+                       /// Returns the absolute value
+                       /// </summary>
+                       [return: NotNullIfNotNull(nameof(a))]
+                       public static Variable? Abs(this Variable? a)
+                       {
+                           if (a is null)
+                               return null;
+
+                           if (a.GetBaseValue() > 0)
+                               return a;
+
+                           return (-a)!;
+                       }
+
+                   }               
                    """;
 
         }

--- a/CodeGen/Code/ExtensionGenerator.cs
+++ b/CodeGen/Code/ExtensionGenerator.cs
@@ -55,7 +55,8 @@ namespace CodeGen
                    using System.Diagnostics.CodeAnalysis;
 
                    namespace EngineeringUnits
-                   {
+                   {                   
+                       // This class is auto-generated, changes to the file will be overwritten!
                        public static class VariableUnitExtension
                        {
 

--- a/CodeGen/Code/ExtensionGenerator.cs
+++ b/CodeGen/Code/ExtensionGenerator.cs
@@ -51,7 +51,6 @@ namespace CodeGen
         {
 
             return $$"""
-                   using System;
                    using System.Diagnostics.CodeAnalysis;
 
                    namespace EngineeringUnits;

--- a/CodeGen/ListOfUnitsForDifferentGenerators.cs
+++ b/CodeGen/ListOfUnitsForDifferentGenerators.cs
@@ -159,6 +159,8 @@ public class ListOfUnitsForDifferentGenerators
         "Pressure",
 
 
+        "Snap",
+
         "SpecificEntropy", //Same as SpecificEntropy
         "SpecificHeatCapacity", //Same as SpecificEntropy
 

--- a/EngineeringUnits/BaseUnits/AmountOfSubstance/AmountOfSubstanceExtension.cs
+++ b/EngineeringUnits/BaseUnits/AmountOfSubstance/AmountOfSubstanceExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class AmountOfSubstanceUnitExtension
     {
 

--- a/EngineeringUnits/BaseUnits/AmountOfSubstance/AmountOfSubstanceExtension.cs
+++ b/EngineeringUnits/BaseUnits/AmountOfSubstance/AmountOfSubstanceExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/BaseUnits/AmountOfSubstance/AmountOfSubstanceExtension.cs
+++ b/EngineeringUnits/BaseUnits/AmountOfSubstance/AmountOfSubstanceExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class AmountOfSubstanceUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class AmountOfSubstanceUnitExtension
+{
+
+    public static AmountOfSubstance IfNullSetToZero(this AmountOfSubstance? local)
     {
-
-        public static AmountOfSubstance IfNullSetToZero(this AmountOfSubstance? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return AmountOfSubstance.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static AmountOfSubstance? Abs(this AmountOfSubstance? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return AmountOfSubstance.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static AmountOfSubstance? Abs(this AmountOfSubstance? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/BaseUnits/Cost/CostExtension.cs
+++ b/EngineeringUnits/BaseUnits/Cost/CostExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class CostUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class CostUnitExtension
+{
+
+    public static Cost IfNullSetToZero(this Cost? local)
     {
-
-        public static Cost IfNullSetToZero(this Cost? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Cost.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Cost? Abs(this Cost? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Cost.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Cost? Abs(this Cost? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/BaseUnits/Cost/CostExtension.cs
+++ b/EngineeringUnits/BaseUnits/Cost/CostExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/BaseUnits/Cost/CostExtension.cs
+++ b/EngineeringUnits/BaseUnits/Cost/CostExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class CostUnitExtension
     {
 

--- a/EngineeringUnits/BaseUnits/Duration/DurationExtension.cs
+++ b/EngineeringUnits/BaseUnits/Duration/DurationExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class DurationUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class DurationUnitExtension
+{
+
+    public static Duration IfNullSetToZero(this Duration? local)
     {
-
-        public static Duration IfNullSetToZero(this Duration? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Duration.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Duration? Abs(this Duration? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Duration.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Duration? Abs(this Duration? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/BaseUnits/Duration/DurationExtension.cs
+++ b/EngineeringUnits/BaseUnits/Duration/DurationExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class DurationUnitExtension
     {
 

--- a/EngineeringUnits/BaseUnits/Duration/DurationExtension.cs
+++ b/EngineeringUnits/BaseUnits/Duration/DurationExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/BaseUnits/Electriccurrent/ElectricCurrentExtension.cs
+++ b/EngineeringUnits/BaseUnits/Electriccurrent/ElectricCurrentExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricCurrentUnitExtension
     {
 

--- a/EngineeringUnits/BaseUnits/Electriccurrent/ElectricCurrentExtension.cs
+++ b/EngineeringUnits/BaseUnits/Electriccurrent/ElectricCurrentExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/BaseUnits/Electriccurrent/ElectricCurrentExtension.cs
+++ b/EngineeringUnits/BaseUnits/Electriccurrent/ElectricCurrentExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricCurrentUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricCurrentUnitExtension
+{
+
+    public static ElectricCurrent IfNullSetToZero(this ElectricCurrent? local)
     {
-
-        public static ElectricCurrent IfNullSetToZero(this ElectricCurrent? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricCurrent.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricCurrent? Abs(this ElectricCurrent? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricCurrent.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricCurrent? Abs(this ElectricCurrent? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/BaseUnits/Length/LengthExtension.cs
+++ b/EngineeringUnits/BaseUnits/Length/LengthExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/BaseUnits/Length/LengthExtension.cs
+++ b/EngineeringUnits/BaseUnits/Length/LengthExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class LengthUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class LengthUnitExtension
+{
+
+    public static Length IfNullSetToZero(this Length? local)
     {
-
-        public static Length IfNullSetToZero(this Length? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Length.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Length? Abs(this Length? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Length.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Length? Abs(this Length? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/BaseUnits/Length/LengthExtension.cs
+++ b/EngineeringUnits/BaseUnits/Length/LengthExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class LengthUnitExtension
     {
 

--- a/EngineeringUnits/BaseUnits/LuminousIntensity/LuminousIntensityExtension.cs
+++ b/EngineeringUnits/BaseUnits/LuminousIntensity/LuminousIntensityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class LuminousIntensityUnitExtension
     {
 

--- a/EngineeringUnits/BaseUnits/LuminousIntensity/LuminousIntensityExtension.cs
+++ b/EngineeringUnits/BaseUnits/LuminousIntensity/LuminousIntensityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/BaseUnits/LuminousIntensity/LuminousIntensityExtension.cs
+++ b/EngineeringUnits/BaseUnits/LuminousIntensity/LuminousIntensityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class LuminousIntensityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class LuminousIntensityUnitExtension
+{
+
+    public static LuminousIntensity IfNullSetToZero(this LuminousIntensity? local)
     {
-
-        public static LuminousIntensity IfNullSetToZero(this LuminousIntensity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return LuminousIntensity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static LuminousIntensity? Abs(this LuminousIntensity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return LuminousIntensity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static LuminousIntensity? Abs(this LuminousIntensity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/BaseUnits/Mass/MassExtension.cs
+++ b/EngineeringUnits/BaseUnits/Mass/MassExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MassUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MassUnitExtension
+{
+
+    public static Mass IfNullSetToZero(this Mass? local)
     {
-
-        public static Mass IfNullSetToZero(this Mass? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Mass.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Mass? Abs(this Mass? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Mass.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Mass? Abs(this Mass? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/BaseUnits/Mass/MassExtension.cs
+++ b/EngineeringUnits/BaseUnits/Mass/MassExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MassUnitExtension
     {
 

--- a/EngineeringUnits/BaseUnits/Mass/MassExtension.cs
+++ b/EngineeringUnits/BaseUnits/Mass/MassExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/BaseUnits/Temperature/TemperatureExtension.cs
+++ b/EngineeringUnits/BaseUnits/Temperature/TemperatureExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/BaseUnits/Temperature/TemperatureExtension.cs
+++ b/EngineeringUnits/BaseUnits/Temperature/TemperatureExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class TemperatureUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class TemperatureUnitExtension
+{
+
+    public static Temperature IfNullSetToZero(this Temperature? local)
     {
-
-        public static Temperature IfNullSetToZero(this Temperature? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Temperature.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Temperature? Abs(this Temperature? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Temperature.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Temperature? Abs(this Temperature? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/BaseUnits/Temperature/TemperatureExtension.cs
+++ b/EngineeringUnits/BaseUnits/Temperature/TemperatureExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class TemperatureUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Acceleration/AccelerationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Acceleration/AccelerationExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class AccelerationUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class AccelerationUnitExtension
+{
+
+    public static Acceleration IfNullSetToZero(this Acceleration? local)
     {
-
-        public static Acceleration IfNullSetToZero(this Acceleration? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Acceleration.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Acceleration? Abs(this Acceleration? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Acceleration.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Acceleration? Abs(this Acceleration? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Acceleration/AccelerationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Acceleration/AccelerationExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class AccelerationUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Acceleration/AccelerationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Acceleration/AccelerationExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Angle/AngleExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Angle/AngleExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Angle/AngleExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Angle/AngleExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class AngleUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Angle/AngleExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Angle/AngleExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class AngleUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class AngleUnitExtension
+{
+
+    public static Angle IfNullSetToZero(this Angle? local)
     {
-
-        public static Angle IfNullSetToZero(this Angle? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Angle.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Angle? Abs(this Angle? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Angle.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Angle? Abs(this Angle? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ApparentPower/ApparentPowerExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ApparentPower/ApparentPowerExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ApparentPowerUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ApparentPower/ApparentPowerExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ApparentPower/ApparentPowerExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ApparentPower/ApparentPowerExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ApparentPower/ApparentPowerExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ApparentPowerUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ApparentPowerUnitExtension
+{
+
+    public static ApparentPower IfNullSetToZero(this ApparentPower? local)
     {
-
-        public static ApparentPower IfNullSetToZero(this ApparentPower? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ApparentPower.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ApparentPower? Abs(this ApparentPower? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ApparentPower.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ApparentPower? Abs(this ApparentPower? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Area/AreaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Area/AreaExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Area/AreaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Area/AreaExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class AreaUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class AreaUnitExtension
+{
+
+    public static Area IfNullSetToZero(this Area? local)
     {
-
-        public static Area IfNullSetToZero(this Area? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Area.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Area? Abs(this Area? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Area.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Area? Abs(this Area? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Area/AreaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Area/AreaExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class AreaUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/AreaCost/AreaCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/AreaCost/AreaCostExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class AreaCostUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class AreaCostUnitExtension
+{
+
+    public static AreaCost IfNullSetToZero(this AreaCost? local)
     {
-
-        public static AreaCost IfNullSetToZero(this AreaCost? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return AreaCost.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static AreaCost? Abs(this AreaCost? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return AreaCost.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static AreaCost? Abs(this AreaCost? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/AreaCost/AreaCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/AreaCost/AreaCostExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/AreaCost/AreaCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/AreaCost/AreaCostExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class AreaCostUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/AreaDensity/AreaDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/AreaDensity/AreaDensityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/AreaDensity/AreaDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/AreaDensity/AreaDensityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class AreaDensityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class AreaDensityUnitExtension
+{
+
+    public static AreaDensity IfNullSetToZero(this AreaDensity? local)
     {
-
-        public static AreaDensity IfNullSetToZero(this AreaDensity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return AreaDensity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static AreaDensity? Abs(this AreaDensity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return AreaDensity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static AreaDensity? Abs(this AreaDensity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/AreaDensity/AreaDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/AreaDensity/AreaDensityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class AreaDensityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/AreaMomentOfInertia/AreaMomentOfInertiaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/AreaMomentOfInertia/AreaMomentOfInertiaExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/AreaMomentOfInertia/AreaMomentOfInertiaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/AreaMomentOfInertia/AreaMomentOfInertiaExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class AreaMomentOfInertiaUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/AreaMomentOfInertia/AreaMomentOfInertiaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/AreaMomentOfInertia/AreaMomentOfInertiaExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class AreaMomentOfInertiaUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class AreaMomentOfInertiaUnitExtension
+{
+
+    public static AreaMomentOfInertia IfNullSetToZero(this AreaMomentOfInertia? local)
     {
-
-        public static AreaMomentOfInertia IfNullSetToZero(this AreaMomentOfInertia? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return AreaMomentOfInertia.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static AreaMomentOfInertia? Abs(this AreaMomentOfInertia? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return AreaMomentOfInertia.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static AreaMomentOfInertia? Abs(this AreaMomentOfInertia? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/BitRate/BitRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/BitRate/BitRateExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class BitRateUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/BitRate/BitRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/BitRate/BitRateExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/BitRate/BitRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/BitRate/BitRateExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class BitRateUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class BitRateUnitExtension
+{
+
+    public static BitRate IfNullSetToZero(this BitRate? local)
     {
-
-        public static BitRate IfNullSetToZero(this BitRate? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return BitRate.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static BitRate? Abs(this BitRate? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return BitRate.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static BitRate? Abs(this BitRate? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/BrakeSpecificFuelConsumption/BrakeSpecificFuelConsumptionExtension.cs
+++ b/EngineeringUnits/CombinedUnits/BrakeSpecificFuelConsumption/BrakeSpecificFuelConsumptionExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class BrakeSpecificFuelConsumptionUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/BrakeSpecificFuelConsumption/BrakeSpecificFuelConsumptionExtension.cs
+++ b/EngineeringUnits/CombinedUnits/BrakeSpecificFuelConsumption/BrakeSpecificFuelConsumptionExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/BrakeSpecificFuelConsumption/BrakeSpecificFuelConsumptionExtension.cs
+++ b/EngineeringUnits/CombinedUnits/BrakeSpecificFuelConsumption/BrakeSpecificFuelConsumptionExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class BrakeSpecificFuelConsumptionUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class BrakeSpecificFuelConsumptionUnitExtension
+{
+
+    public static BrakeSpecificFuelConsumption IfNullSetToZero(this BrakeSpecificFuelConsumption? local)
     {
-
-        public static BrakeSpecificFuelConsumption IfNullSetToZero(this BrakeSpecificFuelConsumption? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return BrakeSpecificFuelConsumption.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static BrakeSpecificFuelConsumption? Abs(this BrakeSpecificFuelConsumption? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return BrakeSpecificFuelConsumption.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static BrakeSpecificFuelConsumption? Abs(this BrakeSpecificFuelConsumption? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Capacitance/CapacitanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Capacitance/CapacitanceExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class CapacitanceUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class CapacitanceUnitExtension
+{
+
+    public static Capacitance IfNullSetToZero(this Capacitance? local)
     {
-
-        public static Capacitance IfNullSetToZero(this Capacitance? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Capacitance.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Capacitance? Abs(this Capacitance? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Capacitance.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Capacitance? Abs(this Capacitance? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Capacitance/CapacitanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Capacitance/CapacitanceExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Capacitance/CapacitanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Capacitance/CapacitanceExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class CapacitanceUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/CoefficientOfThermalExpansion/CoefficientOfThermalExpansionExtension.cs
+++ b/EngineeringUnits/CombinedUnits/CoefficientOfThermalExpansion/CoefficientOfThermalExpansionExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class CoefficientOfThermalExpansionUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/CoefficientOfThermalExpansion/CoefficientOfThermalExpansionExtension.cs
+++ b/EngineeringUnits/CombinedUnits/CoefficientOfThermalExpansion/CoefficientOfThermalExpansionExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class CoefficientOfThermalExpansionUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class CoefficientOfThermalExpansionUnitExtension
+{
+
+    public static CoefficientOfThermalExpansion IfNullSetToZero(this CoefficientOfThermalExpansion? local)
     {
-
-        public static CoefficientOfThermalExpansion IfNullSetToZero(this CoefficientOfThermalExpansion? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return CoefficientOfThermalExpansion.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static CoefficientOfThermalExpansion? Abs(this CoefficientOfThermalExpansion? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return CoefficientOfThermalExpansion.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static CoefficientOfThermalExpansion? Abs(this CoefficientOfThermalExpansion? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/CoefficientOfThermalExpansion/CoefficientOfThermalExpansionExtension.cs
+++ b/EngineeringUnits/CombinedUnits/CoefficientOfThermalExpansion/CoefficientOfThermalExpansionExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Density/DensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Density/DensityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Density/DensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Density/DensityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class DensityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class DensityUnitExtension
+{
+
+    public static Density IfNullSetToZero(this Density? local)
     {
-
-        public static Density IfNullSetToZero(this Density? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Density.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Density? Abs(this Density? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Density.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Density? Abs(this Density? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Density/DensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Density/DensityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class DensityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/DurationCost/DurationCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/DurationCost/DurationCostExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class DurationCostUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class DurationCostUnitExtension
+{
+
+    public static DurationCost IfNullSetToZero(this DurationCost? local)
     {
-
-        public static DurationCost IfNullSetToZero(this DurationCost? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return DurationCost.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static DurationCost? Abs(this DurationCost? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return DurationCost.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static DurationCost? Abs(this DurationCost? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/DurationCost/DurationCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/DurationCost/DurationCostExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/DurationCost/DurationCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/DurationCost/DurationCostExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class DurationCostUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/DynamicViscosity/DynamicViscosityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/DynamicViscosity/DynamicViscosityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/DynamicViscosity/DynamicViscosityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/DynamicViscosity/DynamicViscosityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class DynamicViscosityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/DynamicViscosity/DynamicViscosityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/DynamicViscosity/DynamicViscosityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class DynamicViscosityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class DynamicViscosityUnitExtension
+{
+
+    public static DynamicViscosity IfNullSetToZero(this DynamicViscosity? local)
     {
-
-        public static DynamicViscosity IfNullSetToZero(this DynamicViscosity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return DynamicViscosity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static DynamicViscosity? Abs(this DynamicViscosity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return DynamicViscosity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static DynamicViscosity? Abs(this DynamicViscosity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricChargeUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricChargeUnitExtension
+{
+
+    public static ElectricCharge IfNullSetToZero(this ElectricCharge? local)
     {
-
-        public static ElectricCharge IfNullSetToZero(this ElectricCharge? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricCharge.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricCharge? Abs(this ElectricCharge? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricCharge.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricCharge? Abs(this ElectricCharge? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricChargeUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricChargeDensity/ElectricChargeDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricChargeDensity/ElectricChargeDensityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricChargeDensityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricChargeDensityUnitExtension
+{
+
+    public static ElectricChargeDensity IfNullSetToZero(this ElectricChargeDensity? local)
     {
-
-        public static ElectricChargeDensity IfNullSetToZero(this ElectricChargeDensity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricChargeDensity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricChargeDensity? Abs(this ElectricChargeDensity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricChargeDensity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricChargeDensity? Abs(this ElectricChargeDensity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricChargeDensity/ElectricChargeDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricChargeDensity/ElectricChargeDensityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricChargeDensity/ElectricChargeDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricChargeDensity/ElectricChargeDensityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricChargeDensityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricConductivity/ElectricConductivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricConductivity/ElectricConductivityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricConductivity/ElectricConductivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricConductivity/ElectricConductivityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricConductivityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricConductivity/ElectricConductivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricConductivity/ElectricConductivityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricConductivityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricConductivityUnitExtension
+{
+
+    public static ElectricConductivity IfNullSetToZero(this ElectricConductivity? local)
     {
-
-        public static ElectricConductivity IfNullSetToZero(this ElectricConductivity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricConductivity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricConductivity? Abs(this ElectricConductivity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricConductivity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricConductivity? Abs(this ElectricConductivity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricCurrentDensity/ElectricCurrentDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCurrentDensity/ElectricCurrentDensityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricCurrentDensityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricCurrentDensityUnitExtension
+{
+
+    public static ElectricCurrentDensity IfNullSetToZero(this ElectricCurrentDensity? local)
     {
-
-        public static ElectricCurrentDensity IfNullSetToZero(this ElectricCurrentDensity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricCurrentDensity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricCurrentDensity? Abs(this ElectricCurrentDensity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricCurrentDensity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricCurrentDensity? Abs(this ElectricCurrentDensity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricCurrentDensity/ElectricCurrentDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCurrentDensity/ElectricCurrentDensityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricCurrentDensity/ElectricCurrentDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCurrentDensity/ElectricCurrentDensityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricCurrentDensityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricCurrentGradient/ElectricCurrentGradientExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCurrentGradient/ElectricCurrentGradientExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricCurrentGradient/ElectricCurrentGradientExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCurrentGradient/ElectricCurrentGradientExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricCurrentGradientUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricCurrentGradient/ElectricCurrentGradientExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCurrentGradient/ElectricCurrentGradientExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricCurrentGradientUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricCurrentGradientUnitExtension
+{
+
+    public static ElectricCurrentGradient IfNullSetToZero(this ElectricCurrentGradient? local)
     {
-
-        public static ElectricCurrentGradient IfNullSetToZero(this ElectricCurrentGradient? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricCurrentGradient.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricCurrentGradient? Abs(this ElectricCurrentGradient? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricCurrentGradient.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricCurrentGradient? Abs(this ElectricCurrentGradient? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricField/ElectricFieldExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricField/ElectricFieldExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricFieldUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricFieldUnitExtension
+{
+
+    public static ElectricField IfNullSetToZero(this ElectricField? local)
     {
-
-        public static ElectricField IfNullSetToZero(this ElectricField? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricField.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricField? Abs(this ElectricField? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricField.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricField? Abs(this ElectricField? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricField/ElectricFieldExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricField/ElectricFieldExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricFieldUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricField/ElectricFieldExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricField/ElectricFieldExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricInductance/ElectricInductanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricInductance/ElectricInductanceExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricInductanceUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricInductanceUnitExtension
+{
+
+    public static ElectricInductance IfNullSetToZero(this ElectricInductance? local)
     {
-
-        public static ElectricInductance IfNullSetToZero(this ElectricInductance? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricInductance.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricInductance? Abs(this ElectricInductance? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricInductance.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricInductance? Abs(this ElectricInductance? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricInductance/ElectricInductanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricInductance/ElectricInductanceExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricInductanceUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricInductance/ElectricInductanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricInductance/ElectricInductanceExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricPotential/ElectricPotentialExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricPotential/ElectricPotentialExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricPotentialUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricPotential/ElectricPotentialExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricPotential/ElectricPotentialExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricPotential/ElectricPotentialExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricPotential/ElectricPotentialExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricPotentialUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricPotentialUnitExtension
+{
+
+    public static ElectricPotential IfNullSetToZero(this ElectricPotential? local)
     {
-
-        public static ElectricPotential IfNullSetToZero(this ElectricPotential? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricPotential.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricPotential? Abs(this ElectricPotential? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricPotential.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricPotential? Abs(this ElectricPotential? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricPotentialChangeRate/ElectricPotentialChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricPotentialChangeRate/ElectricPotentialChangeRateExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricPotentialChangeRate/ElectricPotentialChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricPotentialChangeRate/ElectricPotentialChangeRateExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricPotentialChangeRateUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricPotentialChangeRate/ElectricPotentialChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricPotentialChangeRate/ElectricPotentialChangeRateExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricPotentialChangeRateUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricPotentialChangeRateUnitExtension
+{
+
+    public static ElectricPotentialChangeRate IfNullSetToZero(this ElectricPotentialChangeRate? local)
     {
-
-        public static ElectricPotentialChangeRate IfNullSetToZero(this ElectricPotentialChangeRate? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricPotentialChangeRate.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricPotentialChangeRate? Abs(this ElectricPotentialChangeRate? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricPotentialChangeRate.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricPotentialChangeRate? Abs(this ElectricPotentialChangeRate? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricResistance/ElectricResistanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricResistance/ElectricResistanceExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricResistanceUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricResistance/ElectricResistanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricResistance/ElectricResistanceExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricResistance/ElectricResistanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricResistance/ElectricResistanceExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricResistanceUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricResistanceUnitExtension
+{
+
+    public static ElectricResistance IfNullSetToZero(this ElectricResistance? local)
     {
-
-        public static ElectricResistance IfNullSetToZero(this ElectricResistance? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricResistance.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricResistance? Abs(this ElectricResistance? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricResistance.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricResistance? Abs(this ElectricResistance? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricResistivity/ElectricResistivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricResistivity/ElectricResistivityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricResistivityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricResistivityUnitExtension
+{
+
+    public static ElectricResistivity IfNullSetToZero(this ElectricResistivity? local)
     {
-
-        public static ElectricResistivity IfNullSetToZero(this ElectricResistivity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricResistivity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricResistivity? Abs(this ElectricResistivity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricResistivity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricResistivity? Abs(this ElectricResistivity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricResistivity/ElectricResistivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricResistivity/ElectricResistivityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricResistivityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricResistivity/ElectricResistivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricResistivity/ElectricResistivityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ElectricSurfaceChargeDensity/ElectricSurfaceChargeDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricSurfaceChargeDensity/ElectricSurfaceChargeDensityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ElectricSurfaceChargeDensityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ElectricSurfaceChargeDensity/ElectricSurfaceChargeDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricSurfaceChargeDensity/ElectricSurfaceChargeDensityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ElectricSurfaceChargeDensityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ElectricSurfaceChargeDensityUnitExtension
+{
+
+    public static ElectricSurfaceChargeDensity IfNullSetToZero(this ElectricSurfaceChargeDensity? local)
     {
-
-        public static ElectricSurfaceChargeDensity IfNullSetToZero(this ElectricSurfaceChargeDensity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ElectricSurfaceChargeDensity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ElectricSurfaceChargeDensity? Abs(this ElectricSurfaceChargeDensity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ElectricSurfaceChargeDensity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ElectricSurfaceChargeDensity? Abs(this ElectricSurfaceChargeDensity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ElectricSurfaceChargeDensity/ElectricSurfaceChargeDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricSurfaceChargeDensity/ElectricSurfaceChargeDensityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Energy/EnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Energy/EnergyExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Energy/EnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Energy/EnergyExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class EnergyUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class EnergyUnitExtension
+{
+
+    public static Energy IfNullSetToZero(this Energy? local)
     {
-
-        public static Energy IfNullSetToZero(this Energy? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Energy.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Energy? Abs(this Energy? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Energy.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Energy? Abs(this Energy? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Energy/EnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Energy/EnergyExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class EnergyUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/EnergyCost/EnergyCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/EnergyCost/EnergyCostExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/EnergyCost/EnergyCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/EnergyCost/EnergyCostExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class EnergyCostUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/EnergyCost/EnergyCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/EnergyCost/EnergyCostExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class EnergyCostUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class EnergyCostUnitExtension
+{
+
+    public static EnergyCost IfNullSetToZero(this EnergyCost? local)
     {
-
-        public static EnergyCost IfNullSetToZero(this EnergyCost? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return EnergyCost.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static EnergyCost? Abs(this EnergyCost? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return EnergyCost.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static EnergyCost? Abs(this EnergyCost? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Enthalpy/EnthalpyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Enthalpy/EnthalpyExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Enthalpy/EnthalpyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Enthalpy/EnthalpyExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class EnthalpyUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Enthalpy/EnthalpyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Enthalpy/EnthalpyExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class EnthalpyUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class EnthalpyUnitExtension
+{
+
+    public static Enthalpy IfNullSetToZero(this Enthalpy? local)
     {
-
-        public static Enthalpy IfNullSetToZero(this Enthalpy? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Enthalpy.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Enthalpy? Abs(this Enthalpy? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Enthalpy.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Enthalpy? Abs(this Enthalpy? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Entropy/EntropyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Entropy/EntropyExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Entropy/EntropyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Entropy/EntropyExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class EntropyUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class EntropyUnitExtension
+{
+
+    public static Entropy IfNullSetToZero(this Entropy? local)
     {
-
-        public static Entropy IfNullSetToZero(this Entropy? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Entropy.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Entropy? Abs(this Entropy? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Entropy.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Entropy? Abs(this Entropy? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Entropy/EntropyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Entropy/EntropyExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class EntropyUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Force/ForceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Force/ForceExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ForceUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ForceUnitExtension
+{
+
+    public static Force IfNullSetToZero(this Force? local)
     {
-
-        public static Force IfNullSetToZero(this Force? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Force.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Force? Abs(this Force? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Force.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Force? Abs(this Force? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Force/ForceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Force/ForceExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Force/ForceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Force/ForceExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ForceUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ForceChangeRate/ForceChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ForceChangeRate/ForceChangeRateExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ForceChangeRate/ForceChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ForceChangeRate/ForceChangeRateExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ForceChangeRateUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ForceChangeRate/ForceChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ForceChangeRate/ForceChangeRateExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ForceChangeRateUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ForceChangeRateUnitExtension
+{
+
+    public static ForceChangeRate IfNullSetToZero(this ForceChangeRate? local)
     {
-
-        public static ForceChangeRate IfNullSetToZero(this ForceChangeRate? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ForceChangeRate.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ForceChangeRate? Abs(this ForceChangeRate? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ForceChangeRate.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ForceChangeRate? Abs(this ForceChangeRate? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ForceCost/ForceCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ForceCost/ForceCostExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ForceCostUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ForceCostUnitExtension
+{
+
+    public static ForceCost IfNullSetToZero(this ForceCost? local)
     {
-
-        public static ForceCost IfNullSetToZero(this ForceCost? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ForceCost.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ForceCost? Abs(this ForceCost? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ForceCost.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ForceCost? Abs(this ForceCost? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ForceCost/ForceCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ForceCost/ForceCostExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ForceCost/ForceCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ForceCost/ForceCostExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ForceCostUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ForcePerLength/ForcePerLengthExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ForcePerLength/ForcePerLengthExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ForcePerLengthUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ForcePerLengthUnitExtension
+{
+
+    public static ForcePerLength IfNullSetToZero(this ForcePerLength? local)
     {
-
-        public static ForcePerLength IfNullSetToZero(this ForcePerLength? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ForcePerLength.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ForcePerLength? Abs(this ForcePerLength? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ForcePerLength.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ForcePerLength? Abs(this ForcePerLength? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ForcePerLength/ForcePerLengthExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ForcePerLength/ForcePerLengthExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ForcePerLength/ForcePerLengthExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ForcePerLength/ForcePerLengthExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ForcePerLengthUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Frequency/FrequencyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Frequency/FrequencyExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class FrequencyUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class FrequencyUnitExtension
+{
+
+    public static Frequency IfNullSetToZero(this Frequency? local)
     {
-
-        public static Frequency IfNullSetToZero(this Frequency? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Frequency.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Frequency? Abs(this Frequency? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Frequency.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Frequency? Abs(this Frequency? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Frequency/FrequencyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Frequency/FrequencyExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class FrequencyUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Frequency/FrequencyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Frequency/FrequencyExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/FuelEfficiency/FuelEfficiencyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/FuelEfficiency/FuelEfficiencyExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class FuelEfficiencyUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/FuelEfficiency/FuelEfficiencyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/FuelEfficiency/FuelEfficiencyExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/FuelEfficiency/FuelEfficiencyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/FuelEfficiency/FuelEfficiencyExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class FuelEfficiencyUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class FuelEfficiencyUnitExtension
+{
+
+    public static FuelEfficiency IfNullSetToZero(this FuelEfficiency? local)
     {
-
-        public static FuelEfficiency IfNullSetToZero(this FuelEfficiency? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return FuelEfficiency.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static FuelEfficiency? Abs(this FuelEfficiency? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return FuelEfficiency.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static FuelEfficiency? Abs(this FuelEfficiency? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/HeatFlux/HeatFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/HeatFlux/HeatFluxExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class HeatFluxUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/HeatFlux/HeatFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/HeatFlux/HeatFluxExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class HeatFluxUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class HeatFluxUnitExtension
+{
+
+    public static HeatFlux IfNullSetToZero(this HeatFlux? local)
     {
-
-        public static HeatFlux IfNullSetToZero(this HeatFlux? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return HeatFlux.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static HeatFlux? Abs(this HeatFlux? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return HeatFlux.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static HeatFlux? Abs(this HeatFlux? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/HeatFlux/HeatFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/HeatFlux/HeatFluxExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/HeatTransferCoefficient/HeatTransferCoefficientExtension.cs
+++ b/EngineeringUnits/CombinedUnits/HeatTransferCoefficient/HeatTransferCoefficientExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class HeatTransferCoefficientUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class HeatTransferCoefficientUnitExtension
+{
+
+    public static HeatTransferCoefficient IfNullSetToZero(this HeatTransferCoefficient? local)
     {
-
-        public static HeatTransferCoefficient IfNullSetToZero(this HeatTransferCoefficient? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return HeatTransferCoefficient.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static HeatTransferCoefficient? Abs(this HeatTransferCoefficient? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return HeatTransferCoefficient.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static HeatTransferCoefficient? Abs(this HeatTransferCoefficient? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/HeatTransferCoefficient/HeatTransferCoefficientExtension.cs
+++ b/EngineeringUnits/CombinedUnits/HeatTransferCoefficient/HeatTransferCoefficientExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/HeatTransferCoefficient/HeatTransferCoefficientExtension.cs
+++ b/EngineeringUnits/CombinedUnits/HeatTransferCoefficient/HeatTransferCoefficientExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class HeatTransferCoefficientUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Illuminance/IlluminanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Illuminance/IlluminanceExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class IlluminanceUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Illuminance/IlluminanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Illuminance/IlluminanceExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Illuminance/IlluminanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Illuminance/IlluminanceExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class IlluminanceUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class IlluminanceUnitExtension
+{
+
+    public static Illuminance IfNullSetToZero(this Illuminance? local)
     {
-
-        public static Illuminance IfNullSetToZero(this Illuminance? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Illuminance.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Illuminance? Abs(this Illuminance? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Illuminance.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Illuminance? Abs(this Illuminance? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Information/InformationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Information/InformationExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Information/InformationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Information/InformationExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class InformationUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Information/InformationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Information/InformationExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class InformationUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class InformationUnitExtension
+{
+
+    public static Information IfNullSetToZero(this Information? local)
     {
-
-        public static Information IfNullSetToZero(this Information? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Information.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Information? Abs(this Information? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Information.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Information? Abs(this Information? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Irradiance/IrradianceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Irradiance/IrradianceExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Irradiance/IrradianceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Irradiance/IrradianceExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class IrradianceUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Irradiance/IrradianceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Irradiance/IrradianceExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class IrradianceUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class IrradianceUnitExtension
+{
+
+    public static Irradiance IfNullSetToZero(this Irradiance? local)
     {
-
-        public static Irradiance IfNullSetToZero(this Irradiance? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Irradiance.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Irradiance? Abs(this Irradiance? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Irradiance.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Irradiance? Abs(this Irradiance? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Irradiation/IrradiationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Irradiation/IrradiationExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class IrradiationUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class IrradiationUnitExtension
+{
+
+    public static Irradiation IfNullSetToZero(this Irradiation? local)
     {
-
-        public static Irradiation IfNullSetToZero(this Irradiation? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Irradiation.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Irradiation? Abs(this Irradiation? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Irradiation.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Irradiation? Abs(this Irradiation? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Irradiation/IrradiationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Irradiation/IrradiationExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Irradiation/IrradiationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Irradiation/IrradiationExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class IrradiationUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Jerk/JerkExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Jerk/JerkExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class JerkUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Jerk/JerkExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Jerk/JerkExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Jerk/JerkExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Jerk/JerkExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class JerkUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class JerkUnitExtension
+{
+
+    public static Jerk IfNullSetToZero(this Jerk? local)
     {
-
-        public static Jerk IfNullSetToZero(this Jerk? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Jerk.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Jerk? Abs(this Jerk? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Jerk.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Jerk? Abs(this Jerk? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/KinematicViscosity/KinematicViscosityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/KinematicViscosity/KinematicViscosityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class KinematicViscosityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class KinematicViscosityUnitExtension
+{
+
+    public static KinematicViscosity IfNullSetToZero(this KinematicViscosity? local)
     {
-
-        public static KinematicViscosity IfNullSetToZero(this KinematicViscosity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return KinematicViscosity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static KinematicViscosity? Abs(this KinematicViscosity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return KinematicViscosity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static KinematicViscosity? Abs(this KinematicViscosity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/KinematicViscosity/KinematicViscosityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/KinematicViscosity/KinematicViscosityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/KinematicViscosity/KinematicViscosityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/KinematicViscosity/KinematicViscosityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class KinematicViscosityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/LapseRate/LapseRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LapseRate/LapseRateExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class LapseRateUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/LapseRate/LapseRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LapseRate/LapseRateExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class LapseRateUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class LapseRateUnitExtension
+{
+
+    public static LapseRate IfNullSetToZero(this LapseRate? local)
     {
-
-        public static LapseRate IfNullSetToZero(this LapseRate? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return LapseRate.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static LapseRate? Abs(this LapseRate? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return LapseRate.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static LapseRate? Abs(this LapseRate? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/LapseRate/LapseRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LapseRate/LapseRateExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/LengthCost/LengthCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LengthCost/LengthCostExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class LengthCostUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class LengthCostUnitExtension
+{
+
+    public static LengthCost IfNullSetToZero(this LengthCost? local)
     {
-
-        public static LengthCost IfNullSetToZero(this LengthCost? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return LengthCost.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static LengthCost? Abs(this LengthCost? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return LengthCost.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static LengthCost? Abs(this LengthCost? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/LengthCost/LengthCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LengthCost/LengthCostExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/LengthCost/LengthCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LengthCost/LengthCostExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class LengthCostUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/LinearDensity/LinearDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LinearDensity/LinearDensityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/LinearDensity/LinearDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LinearDensity/LinearDensityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class LinearDensityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/LinearDensity/LinearDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LinearDensity/LinearDensityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class LinearDensityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class LinearDensityUnitExtension
+{
+
+    public static LinearDensity IfNullSetToZero(this LinearDensity? local)
     {
-
-        public static LinearDensity IfNullSetToZero(this LinearDensity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return LinearDensity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static LinearDensity? Abs(this LinearDensity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return LinearDensity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static LinearDensity? Abs(this LinearDensity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/LinearPowerDensity/LinearPowerDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LinearPowerDensity/LinearPowerDensityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/LinearPowerDensity/LinearPowerDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LinearPowerDensity/LinearPowerDensityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class LinearPowerDensityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/LinearPowerDensity/LinearPowerDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LinearPowerDensity/LinearPowerDensityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class LinearPowerDensityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class LinearPowerDensityUnitExtension
+{
+
+    public static LinearPowerDensity IfNullSetToZero(this LinearPowerDensity? local)
     {
-
-        public static LinearPowerDensity IfNullSetToZero(this LinearPowerDensity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return LinearPowerDensity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static LinearPowerDensity? Abs(this LinearPowerDensity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return LinearPowerDensity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static LinearPowerDensity? Abs(this LinearPowerDensity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/LuminousFlux/LuminousFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LuminousFlux/LuminousFluxExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class LuminousFluxUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class LuminousFluxUnitExtension
+{
+
+    public static LuminousFlux IfNullSetToZero(this LuminousFlux? local)
     {
-
-        public static LuminousFlux IfNullSetToZero(this LuminousFlux? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return LuminousFlux.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static LuminousFlux? Abs(this LuminousFlux? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return LuminousFlux.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static LuminousFlux? Abs(this LuminousFlux? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/LuminousFlux/LuminousFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LuminousFlux/LuminousFluxExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class LuminousFluxUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/LuminousFlux/LuminousFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/LuminousFlux/LuminousFluxExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MagneticField/MagneticFieldExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MagneticField/MagneticFieldExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MagneticFieldUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/MagneticField/MagneticFieldExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MagneticField/MagneticFieldExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MagneticFieldUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MagneticFieldUnitExtension
+{
+
+    public static MagneticField IfNullSetToZero(this MagneticField? local)
     {
-
-        public static MagneticField IfNullSetToZero(this MagneticField? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return MagneticField.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static MagneticField? Abs(this MagneticField? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return MagneticField.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static MagneticField? Abs(this MagneticField? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/MagneticField/MagneticFieldExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MagneticField/MagneticFieldExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MagneticFlux/MagneticFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MagneticFlux/MagneticFluxExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MagneticFluxUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MagneticFluxUnitExtension
+{
+
+    public static MagneticFlux IfNullSetToZero(this MagneticFlux? local)
     {
-
-        public static MagneticFlux IfNullSetToZero(this MagneticFlux? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return MagneticFlux.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static MagneticFlux? Abs(this MagneticFlux? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return MagneticFlux.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static MagneticFlux? Abs(this MagneticFlux? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/MagneticFlux/MagneticFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MagneticFlux/MagneticFluxExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MagneticFlux/MagneticFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MagneticFlux/MagneticFluxExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MagneticFluxUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Magnetization/MagnetizationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Magnetization/MagnetizationExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MagnetizationUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MagnetizationUnitExtension
+{
+
+    public static Magnetization IfNullSetToZero(this Magnetization? local)
     {
-
-        public static Magnetization IfNullSetToZero(this Magnetization? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Magnetization.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Magnetization? Abs(this Magnetization? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Magnetization.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Magnetization? Abs(this Magnetization? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Magnetization/MagnetizationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Magnetization/MagnetizationExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MagnetizationUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Magnetization/MagnetizationExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Magnetization/MagnetizationExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MassCost/MassCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassCost/MassCostExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MassCostUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MassCostUnitExtension
+{
+
+    public static MassCost IfNullSetToZero(this MassCost? local)
     {
-
-        public static MassCost IfNullSetToZero(this MassCost? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return MassCost.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static MassCost? Abs(this MassCost? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return MassCost.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static MassCost? Abs(this MassCost? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/MassCost/MassCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassCost/MassCostExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MassCostUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/MassCost/MassCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassCost/MassCostExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MassFlow/MassFlowExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassFlow/MassFlowExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MassFlowUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MassFlowUnitExtension
+{
+
+    public static MassFlow IfNullSetToZero(this MassFlow? local)
     {
-
-        public static MassFlow IfNullSetToZero(this MassFlow? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return MassFlow.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static MassFlow? Abs(this MassFlow? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return MassFlow.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static MassFlow? Abs(this MassFlow? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/MassFlow/MassFlowExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassFlow/MassFlowExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MassFlow/MassFlowExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassFlow/MassFlowExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MassFlowUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/MassFlux/MassFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassFlux/MassFluxExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MassFlux/MassFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassFlux/MassFluxExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MassFluxUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MassFluxUnitExtension
+{
+
+    public static MassFlux IfNullSetToZero(this MassFlux? local)
     {
-
-        public static MassFlux IfNullSetToZero(this MassFlux? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return MassFlux.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static MassFlux? Abs(this MassFlux? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return MassFlux.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static MassFlux? Abs(this MassFlux? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/MassFlux/MassFluxExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassFlux/MassFluxExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MassFluxUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/MassMomentOfInertia/MassMomentOfInertiaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassMomentOfInertia/MassMomentOfInertiaExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MassMomentOfInertiaUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MassMomentOfInertiaUnitExtension
+{
+
+    public static MassMomentOfInertia IfNullSetToZero(this MassMomentOfInertia? local)
     {
-
-        public static MassMomentOfInertia IfNullSetToZero(this MassMomentOfInertia? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return MassMomentOfInertia.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static MassMomentOfInertia? Abs(this MassMomentOfInertia? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return MassMomentOfInertia.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static MassMomentOfInertia? Abs(this MassMomentOfInertia? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/MassMomentOfInertia/MassMomentOfInertiaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassMomentOfInertia/MassMomentOfInertiaExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MassMomentOfInertia/MassMomentOfInertiaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MassMomentOfInertia/MassMomentOfInertiaExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MassMomentOfInertiaUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/MolarEnergy/MolarEnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarEnergy/MolarEnergyExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MolarEnergy/MolarEnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarEnergy/MolarEnergyExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MolarEnergyUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MolarEnergyUnitExtension
+{
+
+    public static MolarEnergy IfNullSetToZero(this MolarEnergy? local)
     {
-
-        public static MolarEnergy IfNullSetToZero(this MolarEnergy? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return MolarEnergy.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static MolarEnergy? Abs(this MolarEnergy? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return MolarEnergy.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static MolarEnergy? Abs(this MolarEnergy? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/MolarEnergy/MolarEnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarEnergy/MolarEnergyExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MolarEnergyUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/MolarEntropy/MolarEntropyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarEntropy/MolarEntropyExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MolarEntropyUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/MolarEntropy/MolarEntropyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarEntropy/MolarEntropyExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MolarEntropy/MolarEntropyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarEntropy/MolarEntropyExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MolarEntropyUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MolarEntropyUnitExtension
+{
+
+    public static MolarEntropy IfNullSetToZero(this MolarEntropy? local)
     {
-
-        public static MolarEntropy IfNullSetToZero(this MolarEntropy? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return MolarEntropy.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static MolarEntropy? Abs(this MolarEntropy? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return MolarEntropy.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static MolarEntropy? Abs(this MolarEntropy? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/MolarFlow/MolarFlowExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarFlow/MolarFlowExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MolarFlowUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MolarFlowUnitExtension
+{
+
+    public static MolarFlow IfNullSetToZero(this MolarFlow? local)
     {
-
-        public static MolarFlow IfNullSetToZero(this MolarFlow? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return MolarFlow.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static MolarFlow? Abs(this MolarFlow? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return MolarFlow.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static MolarFlow? Abs(this MolarFlow? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/MolarFlow/MolarFlowExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarFlow/MolarFlowExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MolarFlowUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/MolarFlow/MolarFlowExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarFlow/MolarFlowExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MolarMass/MolarMassExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarMass/MolarMassExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/MolarMass/MolarMassExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarMass/MolarMassExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MolarMassUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MolarMassUnitExtension
+{
+
+    public static MolarMass IfNullSetToZero(this MolarMass? local)
     {
-
-        public static MolarMass IfNullSetToZero(this MolarMass? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return MolarMass.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static MolarMass? Abs(this MolarMass? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return MolarMass.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static MolarMass? Abs(this MolarMass? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/MolarMass/MolarMassExtension.cs
+++ b/EngineeringUnits/CombinedUnits/MolarMass/MolarMassExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MolarMassUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Molarity/MolarityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Molarity/MolarityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class MolarityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Molarity/MolarityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Molarity/MolarityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Molarity/MolarityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Molarity/MolarityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class MolarityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class MolarityUnitExtension
+{
+
+    public static Molarity IfNullSetToZero(this Molarity? local)
     {
-
-        public static Molarity IfNullSetToZero(this Molarity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Molarity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Molarity? Abs(this Molarity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Molarity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Molarity? Abs(this Molarity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Permeability/PermeabilityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Permeability/PermeabilityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class PermeabilityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Permeability/PermeabilityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Permeability/PermeabilityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Permeability/PermeabilityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Permeability/PermeabilityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class PermeabilityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class PermeabilityUnitExtension
+{
+
+    public static Permeability IfNullSetToZero(this Permeability? local)
     {
-
-        public static Permeability IfNullSetToZero(this Permeability? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Permeability.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Permeability? Abs(this Permeability? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Permeability.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Permeability? Abs(this Permeability? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Permittivity/PermittivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Permittivity/PermittivityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class PermittivityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Permittivity/PermittivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Permittivity/PermittivityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Permittivity/PermittivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Permittivity/PermittivityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class PermittivityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class PermittivityUnitExtension
+{
+
+    public static Permittivity IfNullSetToZero(this Permittivity? local)
     {
-
-        public static Permittivity IfNullSetToZero(this Permittivity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Permittivity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Permittivity? Abs(this Permittivity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Permittivity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Permittivity? Abs(this Permittivity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/PipeSize/PipeSizeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PipeSize/PipeSizeExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class PipeSizeUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/PipeSize/PipeSizeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PipeSize/PipeSizeExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/PipeSize/PipeSizeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PipeSize/PipeSizeExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class PipeSizeUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class PipeSizeUnitExtension
+{
+
+    public static PipeSize IfNullSetToZero(this PipeSize? local)
     {
-
-        public static PipeSize IfNullSetToZero(this PipeSize? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return PipeSize.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static PipeSize? Abs(this PipeSize? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return PipeSize.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static PipeSize? Abs(this PipeSize? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Power/PowerExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Power/PowerExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class PowerUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Power/PowerExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Power/PowerExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Power/PowerExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Power/PowerExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class PowerUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class PowerUnitExtension
+{
+
+    public static Power IfNullSetToZero(this Power? local)
     {
-
-        public static Power IfNullSetToZero(this Power? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Power.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Power? Abs(this Power? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Power.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Power? Abs(this Power? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/PowerCost/PowerCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PowerCost/PowerCostExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class PowerCostUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class PowerCostUnitExtension
+{
+
+    public static PowerCost IfNullSetToZero(this PowerCost? local)
     {
-
-        public static PowerCost IfNullSetToZero(this PowerCost? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return PowerCost.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static PowerCost? Abs(this PowerCost? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return PowerCost.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static PowerCost? Abs(this PowerCost? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/PowerCost/PowerCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PowerCost/PowerCostExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/PowerCost/PowerCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PowerCost/PowerCostExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class PowerCostUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/PowerDensity/PowerDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PowerDensity/PowerDensityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class PowerDensityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/PowerDensity/PowerDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PowerDensity/PowerDensityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/PowerDensity/PowerDensityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PowerDensity/PowerDensityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class PowerDensityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class PowerDensityUnitExtension
+{
+
+    public static PowerDensity IfNullSetToZero(this PowerDensity? local)
     {
-
-        public static PowerDensity IfNullSetToZero(this PowerDensity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return PowerDensity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static PowerDensity? Abs(this PowerDensity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return PowerDensity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static PowerDensity? Abs(this PowerDensity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Pressure/PressureExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Pressure/PressureExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Pressure/PressureExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Pressure/PressureExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class PressureUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class PressureUnitExtension
+{
+
+    public static Pressure IfNullSetToZero(this Pressure? local)
     {
-
-        public static Pressure IfNullSetToZero(this Pressure? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Pressure.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Pressure? Abs(this Pressure? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Pressure.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Pressure? Abs(this Pressure? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Pressure/PressureExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Pressure/PressureExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class PressureUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/PressureChangeRate/PressureChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PressureChangeRate/PressureChangeRateExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class PressureChangeRateUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/PressureChangeRate/PressureChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PressureChangeRate/PressureChangeRateExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/PressureChangeRate/PressureChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/PressureChangeRate/PressureChangeRateExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class PressureChangeRateUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class PressureChangeRateUnitExtension
+{
+
+    public static PressureChangeRate IfNullSetToZero(this PressureChangeRate? local)
     {
-
-        public static PressureChangeRate IfNullSetToZero(this PressureChangeRate? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return PressureChangeRate.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static PressureChangeRate? Abs(this PressureChangeRate? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return PressureChangeRate.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static PressureChangeRate? Abs(this PressureChangeRate? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Ratio/RatioExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Ratio/RatioExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class RatioUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Ratio/RatioExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Ratio/RatioExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Ratio/RatioExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Ratio/RatioExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class RatioUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class RatioUnitExtension
+{
+
+    public static Ratio IfNullSetToZero(this Ratio? local)
     {
-
-        public static Ratio IfNullSetToZero(this Ratio? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Ratio.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Ratio? Abs(this Ratio? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Ratio.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Ratio? Abs(this Ratio? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ReactiveEnergy/ReactiveEnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ReactiveEnergy/ReactiveEnergyExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ReactiveEnergyUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ReactiveEnergyUnitExtension
+{
+
+    public static ReactiveEnergy IfNullSetToZero(this ReactiveEnergy? local)
     {
-
-        public static ReactiveEnergy IfNullSetToZero(this ReactiveEnergy? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ReactiveEnergy.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ReactiveEnergy? Abs(this ReactiveEnergy? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ReactiveEnergy.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ReactiveEnergy? Abs(this ReactiveEnergy? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ReactiveEnergy/ReactiveEnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ReactiveEnergy/ReactiveEnergyExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ReactiveEnergy/ReactiveEnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ReactiveEnergy/ReactiveEnergyExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ReactiveEnergyUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ReactivePower/ReactivePowerExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ReactivePower/ReactivePowerExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ReactivePowerUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ReactivePower/ReactivePowerExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ReactivePower/ReactivePowerExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ReactivePower/ReactivePowerExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ReactivePower/ReactivePowerExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ReactivePowerUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ReactivePowerUnitExtension
+{
+
+    public static ReactivePower IfNullSetToZero(this ReactivePower? local)
     {
-
-        public static ReactivePower IfNullSetToZero(this ReactivePower? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ReactivePower.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ReactivePower? Abs(this ReactivePower? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ReactivePower.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ReactivePower? Abs(this ReactivePower? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/RotationalSpeed/RotationalSpeedExtension.cs
+++ b/EngineeringUnits/CombinedUnits/RotationalSpeed/RotationalSpeedExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class RotationalSpeedUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/RotationalSpeed/RotationalSpeedExtension.cs
+++ b/EngineeringUnits/CombinedUnits/RotationalSpeed/RotationalSpeedExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/RotationalSpeed/RotationalSpeedExtension.cs
+++ b/EngineeringUnits/CombinedUnits/RotationalSpeed/RotationalSpeedExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class RotationalSpeedUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class RotationalSpeedUnitExtension
+{
+
+    public static RotationalSpeed IfNullSetToZero(this RotationalSpeed? local)
     {
-
-        public static RotationalSpeed IfNullSetToZero(this RotationalSpeed? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return RotationalSpeed.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static RotationalSpeed? Abs(this RotationalSpeed? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return RotationalSpeed.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static RotationalSpeed? Abs(this RotationalSpeed? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Snap/Snap.cs
+++ b/EngineeringUnits/CombinedUnits/Snap/Snap.cs
@@ -1,0 +1,50 @@
+using EngineeringUnits.Units;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public partial class Snap : BaseUnit
+{
+    public Snap() { }
+    public Snap(decimal value, SnapUnit selectedUnit) : base(value, selectedUnit.Unit) { }
+    public Snap(double value, SnapUnit selectedUnit) : base(value, selectedUnit.Unit) { }
+    public Snap(int value, SnapUnit selectedUnit) : base(value, selectedUnit.Unit) { }
+    public Snap(UnknownUnit value) : base(value) { }
+
+    public static Snap From(double value, SnapUnit unit) => new(value, unit);
+
+    [return: NotNullIfNotNull(nameof(value))]
+    public static Snap? From(double? value, SnapUnit? unit)
+    {
+        if (value is null || unit is null)
+            return null;
+
+        return From((double)value, unit);
+    }
+    public double As(SnapUnit ReturnInThisUnit) => this.GetValueAsDouble(ReturnInThisUnit);
+    public Snap ToUnit(SnapUnit selectedUnit) => new(this.GetValueAs(selectedUnit.Unit), selectedUnit);
+    public static Snap Zero => new(0, SnapUnit.SI);
+    public static Snap NaN => new(double.NaN, SnapUnit.SI);
+
+    [return: NotNullIfNotNull(nameof(Unit))]
+    public static implicit operator Snap?(UnknownUnit? Unit)
+    {
+        if (Unit is null)
+            return null;
+
+        GuardAgainst.DifferentUnits(Unit, SnapUnit.SI);
+        return new(Unit);
+    }
+
+    [return: NotNullIfNotNull(nameof(Unit))]
+    public static implicit operator UnknownUnit?(Snap? Unit)
+    {
+        if (Unit is null)
+            return null;
+
+        return new(Unit);
+    }
+
+    public override string? GetStandardSymbol(UnitSystem _unit) => GetStandardSymbol<SnapUnit>(_unit);
+}

--- a/EngineeringUnits/CombinedUnits/Snap/SnapEnum.cs
+++ b/EngineeringUnits/CombinedUnits/Snap/SnapEnum.cs
@@ -1,0 +1,26 @@
+﻿namespace EngineeringUnits.Units;
+
+public partial record SnapUnit : UnitTypebase
+{
+    public static readonly SnapUnit SI = new(LengthUnit.SI, DurationUnit.SI);
+    public static readonly SnapUnit KilometerPerSecond4 = new(LengthUnit.Kilometer, DurationUnit.Second);
+    public static readonly SnapUnit MeterPerSecond4 = new(LengthUnit.SI, DurationUnit.SI);
+    public static readonly SnapUnit DecimeterPerSecond4 = new(LengthUnit.Decimeter, DurationUnit.Second);
+    public static readonly SnapUnit CentimeterPerSecond4 = new(LengthUnit.Centimeter, DurationUnit.Second);
+    public static readonly SnapUnit MicrometerPerSecond4 = new(LengthUnit.Micrometer, DurationUnit.Second);
+    public static readonly SnapUnit MillimeterPerSecond4 = new(LengthUnit.Millimeter, DurationUnit.Second);
+    public static readonly SnapUnit NanometerPerSecond4 = new(LengthUnit.Nanometer, DurationUnit.Second);
+
+    public SnapUnit(LengthUnit length, DurationUnit duration)
+    {
+        Unit = length / duration.Pow(4);
+    }
+
+    public override string ToString()
+    {
+        if (Unit.Symbol is not null)
+            return $"{Unit.Symbol}";
+
+        return $"{Unit}";
+    }
+}

--- a/EngineeringUnits/CombinedUnits/Snap/SnapExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Snap/SnapExtension.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EngineeringUnits
+{                   
+    public static class SnapUnitExtension
+    {
+
+        public static Snap IfNullSetToZero(this Snap? local)
+        {
+            if (local is not null)
+            {
+                return local;
+            }
+
+            return Snap.Zero;
+        }
+
+
+        /// <summary>
+        /// Returns the absolute value
+        /// </summary>
+        [return: NotNullIfNotNull(nameof(a))]
+        public static Snap? Abs(this Snap? a)
+        {
+            if (a is null)
+                return null;
+
+            if (a.GetBaseValue() > 0)
+                return a;
+
+            return (-a)!;
+        }
+
+    }
+}                   

--- a/EngineeringUnits/CombinedUnits/Snap/SnapExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Snap/SnapExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class SnapUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class SnapUnitExtension
+{
+
+    public static Snap IfNullSetToZero(this Snap? local)
     {
-
-        public static Snap IfNullSetToZero(this Snap? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Snap.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Snap? Abs(this Snap? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Snap.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Snap? Abs(this Snap? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/Snap/SnapExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Snap/SnapExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Snap/SnapExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Snap/SnapExtension.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
 {                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class SnapUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Snap/SnapGet.cs
+++ b/EngineeringUnits/CombinedUnits/Snap/SnapGet.cs
@@ -1,0 +1,42 @@
+using EngineeringUnits.Units;
+
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public partial class Snap
+{
+
+    /// <summary>
+    /// Get Snap in SI.
+    /// </summary>
+    public double SI => As(SnapUnit.SI);
+    /// <summary>
+    /// Get Snap in KilometerPerSecond4.
+    /// </summary>
+    public double KilometerPerSecond4 => As(SnapUnit.KilometerPerSecond4);
+    /// <summary>
+    /// Get Snap in MeterPerSecond4.
+    /// </summary>
+    public double MeterPerSecond4 => As(SnapUnit.MeterPerSecond4);
+    /// <summary>
+    /// Get Snap in DecimeterPerSecond4.
+    /// </summary>
+    public double DecimeterPerSecond4 => As(SnapUnit.DecimeterPerSecond4);
+    /// <summary>
+    /// Get Snap in CentimeterPerSecond4.
+    /// </summary>
+    public double CentimeterPerSecond4 => As(SnapUnit.CentimeterPerSecond4);
+    /// <summary>
+    /// Get Snap in MicrometerPerSecond4.
+    /// </summary>
+    public double MicrometerPerSecond4 => As(SnapUnit.MicrometerPerSecond4);
+    /// <summary>
+    /// Get Snap in MillimeterPerSecond4.
+    /// </summary>
+    public double MillimeterPerSecond4 => As(SnapUnit.MillimeterPerSecond4);
+    /// <summary>
+    /// Get Snap in NanometerPerSecond4.
+    /// </summary>
+    public double NanometerPerSecond4 => As(SnapUnit.NanometerPerSecond4);
+
+}

--- a/EngineeringUnits/CombinedUnits/Snap/SnapSet.cs
+++ b/EngineeringUnits/CombinedUnits/Snap/SnapSet.cs
@@ -1,0 +1,107 @@
+using EngineeringUnits.Units;
+using System.Diagnostics.CodeAnalysis;
+
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public partial class Snap
+{
+
+    /// <summary>
+    /// Get Snap from SI.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(SI))]
+    public static Snap? FromSI(double? SI)
+    {
+        if (SI is null)
+            return null;
+        
+        return new Snap((double)SI, SnapUnit.SI);
+    }
+    /// <summary>
+    /// Get Snap from KilometerPerSecond4.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(KilometerPerSecond4))]
+    public static Snap? FromKilometerPerSecond4(double? KilometerPerSecond4)
+    {
+        if (KilometerPerSecond4 is null)
+            return null;
+        
+        return new Snap((double)KilometerPerSecond4, SnapUnit.KilometerPerSecond4);
+    }
+    /// <summary>
+    /// Get Snap from MeterPerSecond4.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(MeterPerSecond4))]
+    public static Snap? FromMeterPerSecond4(double? MeterPerSecond4)
+    {
+        if (MeterPerSecond4 is null)
+            return null;
+        
+        return new Snap((double)MeterPerSecond4, SnapUnit.MeterPerSecond4);
+    }
+    /// <summary>
+    /// Get Snap from DecimeterPerSecond4.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(DecimeterPerSecond4))]
+    public static Snap? FromDecimeterPerSecond4(double? DecimeterPerSecond4)
+    {
+        if (DecimeterPerSecond4 is null)
+            return null;
+        
+        return new Snap((double)DecimeterPerSecond4, SnapUnit.DecimeterPerSecond4);
+    }
+    /// <summary>
+    /// Get Snap from CentimeterPerSecond4.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(CentimeterPerSecond4))]
+    public static Snap? FromCentimeterPerSecond4(double? CentimeterPerSecond4)
+    {
+        if (CentimeterPerSecond4 is null)
+            return null;
+        
+        return new Snap((double)CentimeterPerSecond4, SnapUnit.CentimeterPerSecond4);
+    }
+    /// <summary>
+    /// Get Snap from MicrometerPerSecond4.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(MicrometerPerSecond4))]
+    public static Snap? FromMicrometerPerSecond4(double? MicrometerPerSecond4)
+    {
+        if (MicrometerPerSecond4 is null)
+            return null;
+        
+        return new Snap((double)MicrometerPerSecond4, SnapUnit.MicrometerPerSecond4);
+    }
+    /// <summary>
+    /// Get Snap from MillimeterPerSecond4.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(MillimeterPerSecond4))]
+    public static Snap? FromMillimeterPerSecond4(double? MillimeterPerSecond4)
+    {
+        if (MillimeterPerSecond4 is null)
+            return null;
+        
+        return new Snap((double)MillimeterPerSecond4, SnapUnit.MillimeterPerSecond4);
+    }
+    /// <summary>
+    /// Get Snap from NanometerPerSecond4.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(NanometerPerSecond4))]
+    public static Snap? FromNanometerPerSecond4(double? NanometerPerSecond4)
+    {
+        if (NanometerPerSecond4 is null)
+            return null;
+        
+        return new Snap((double)NanometerPerSecond4, SnapUnit.NanometerPerSecond4);
+    }
+
+}

--- a/EngineeringUnits/CombinedUnits/SpecificEnergy/SpecificEnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificEnergy/SpecificEnergyExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class SpecificEnergyUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class SpecificEnergyUnitExtension
+{
+
+    public static SpecificEnergy IfNullSetToZero(this SpecificEnergy? local)
     {
-
-        public static SpecificEnergy IfNullSetToZero(this SpecificEnergy? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return SpecificEnergy.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static SpecificEnergy? Abs(this SpecificEnergy? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return SpecificEnergy.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static SpecificEnergy? Abs(this SpecificEnergy? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/SpecificEnergy/SpecificEnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificEnergy/SpecificEnergyExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/SpecificEnergy/SpecificEnergyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificEnergy/SpecificEnergyExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class SpecificEnergyUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/SpecificEntropy/SpecificEntropyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificEntropy/SpecificEntropyExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class SpecificEntropyUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class SpecificEntropyUnitExtension
+{
+
+    public static SpecificEntropy IfNullSetToZero(this SpecificEntropy? local)
     {
-
-        public static SpecificEntropy IfNullSetToZero(this SpecificEntropy? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return SpecificEntropy.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static SpecificEntropy? Abs(this SpecificEntropy? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return SpecificEntropy.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static SpecificEntropy? Abs(this SpecificEntropy? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/SpecificEntropy/SpecificEntropyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificEntropy/SpecificEntropyExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/SpecificEntropy/SpecificEntropyExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificEntropy/SpecificEntropyExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class SpecificEntropyUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/SpecificHeatCapacity/SpecificHeatCapacityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificHeatCapacity/SpecificHeatCapacityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class SpecificHeatCapacityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class SpecificHeatCapacityUnitExtension
+{
+
+    public static SpecificHeatCapacity IfNullSetToZero(this SpecificHeatCapacity? local)
     {
-
-        public static SpecificHeatCapacity IfNullSetToZero(this SpecificHeatCapacity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return SpecificHeatCapacity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static SpecificHeatCapacity? Abs(this SpecificHeatCapacity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return SpecificHeatCapacity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static SpecificHeatCapacity? Abs(this SpecificHeatCapacity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/SpecificHeatCapacity/SpecificHeatCapacityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificHeatCapacity/SpecificHeatCapacityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/SpecificHeatCapacity/SpecificHeatCapacityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificHeatCapacity/SpecificHeatCapacityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class SpecificHeatCapacityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/SpecificThermalResistance/SpecificThermalResistanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificThermalResistance/SpecificThermalResistanceExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/SpecificThermalResistance/SpecificThermalResistanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificThermalResistance/SpecificThermalResistanceExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class SpecificThermalResistanceUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/SpecificThermalResistance/SpecificThermalResistanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificThermalResistance/SpecificThermalResistanceExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class SpecificThermalResistanceUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class SpecificThermalResistanceUnitExtension
+{
+
+    public static SpecificThermalResistance IfNullSetToZero(this SpecificThermalResistance? local)
     {
-
-        public static SpecificThermalResistance IfNullSetToZero(this SpecificThermalResistance? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return SpecificThermalResistance.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static SpecificThermalResistance? Abs(this SpecificThermalResistance? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return SpecificThermalResistance.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static SpecificThermalResistance? Abs(this SpecificThermalResistance? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/SpecificVolume/SpecificVolumeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificVolume/SpecificVolumeExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class SpecificVolumeUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class SpecificVolumeUnitExtension
+{
+
+    public static SpecificVolume IfNullSetToZero(this SpecificVolume? local)
     {
-
-        public static SpecificVolume IfNullSetToZero(this SpecificVolume? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return SpecificVolume.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static SpecificVolume? Abs(this SpecificVolume? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return SpecificVolume.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static SpecificVolume? Abs(this SpecificVolume? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/SpecificVolume/SpecificVolumeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificVolume/SpecificVolumeExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/SpecificVolume/SpecificVolumeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificVolume/SpecificVolumeExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class SpecificVolumeUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/SpecificWeight/SpecificWeightExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificWeight/SpecificWeightExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class SpecificWeightUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class SpecificWeightUnitExtension
+{
+
+    public static SpecificWeight IfNullSetToZero(this SpecificWeight? local)
     {
-
-        public static SpecificWeight IfNullSetToZero(this SpecificWeight? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return SpecificWeight.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static SpecificWeight? Abs(this SpecificWeight? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return SpecificWeight.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static SpecificWeight? Abs(this SpecificWeight? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/SpecificWeight/SpecificWeightExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificWeight/SpecificWeightExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/SpecificWeight/SpecificWeightExtension.cs
+++ b/EngineeringUnits/CombinedUnits/SpecificWeight/SpecificWeightExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class SpecificWeightUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Speed/SpeedExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Speed/SpeedExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Speed/SpeedExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Speed/SpeedExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class SpeedUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Speed/SpeedExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Speed/SpeedExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class SpeedUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class SpeedUnitExtension
+{
+
+    public static Speed IfNullSetToZero(this Speed? local)
     {
-
-        public static Speed IfNullSetToZero(this Speed? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Speed.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Speed? Abs(this Speed? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Speed.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Speed? Abs(this Speed? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/TemperatureChangeRate/TemperatureChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/TemperatureChangeRate/TemperatureChangeRateExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/TemperatureChangeRate/TemperatureChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/TemperatureChangeRate/TemperatureChangeRateExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class TemperatureChangeRateUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class TemperatureChangeRateUnitExtension
+{
+
+    public static TemperatureChangeRate IfNullSetToZero(this TemperatureChangeRate? local)
     {
-
-        public static TemperatureChangeRate IfNullSetToZero(this TemperatureChangeRate? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return TemperatureChangeRate.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static TemperatureChangeRate? Abs(this TemperatureChangeRate? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return TemperatureChangeRate.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static TemperatureChangeRate? Abs(this TemperatureChangeRate? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/TemperatureChangeRate/TemperatureChangeRateExtension.cs
+++ b/EngineeringUnits/CombinedUnits/TemperatureChangeRate/TemperatureChangeRateExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class TemperatureChangeRateUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ThermalConductivity/ThermalConductivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ThermalConductivity/ThermalConductivityExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/ThermalConductivity/ThermalConductivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ThermalConductivity/ThermalConductivityExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ThermalConductivityUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ThermalConductivity/ThermalConductivityExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ThermalConductivity/ThermalConductivityExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ThermalConductivityUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ThermalConductivityUnitExtension
+{
+
+    public static ThermalConductivity IfNullSetToZero(this ThermalConductivity? local)
     {
-
-        public static ThermalConductivity IfNullSetToZero(this ThermalConductivity? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ThermalConductivity.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ThermalConductivity? Abs(this ThermalConductivity? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ThermalConductivity.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ThermalConductivity? Abs(this ThermalConductivity? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ThermalResistance/ThermalResistanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ThermalResistance/ThermalResistanceExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class ThermalResistanceUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/ThermalResistance/ThermalResistanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ThermalResistance/ThermalResistanceExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class ThermalResistanceUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class ThermalResistanceUnitExtension
+{
+
+    public static ThermalResistance IfNullSetToZero(this ThermalResistance? local)
     {
-
-        public static ThermalResistance IfNullSetToZero(this ThermalResistance? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return ThermalResistance.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static ThermalResistance? Abs(this ThermalResistance? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return ThermalResistance.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static ThermalResistance? Abs(this ThermalResistance? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/ThermalResistance/ThermalResistanceExtension.cs
+++ b/EngineeringUnits/CombinedUnits/ThermalResistance/ThermalResistanceExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Torque/TorqueExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Torque/TorqueExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class TorqueUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Torque/TorqueExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Torque/TorqueExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Torque/TorqueExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Torque/TorqueExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class TorqueUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class TorqueUnitExtension
+{
+
+    public static Torque IfNullSetToZero(this Torque? local)
     {
-
-        public static Torque IfNullSetToZero(this Torque? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Torque.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Torque? Abs(this Torque? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Torque.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Torque? Abs(this Torque? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/TorquePerLength/TorquePerLengthExtension.cs
+++ b/EngineeringUnits/CombinedUnits/TorquePerLength/TorquePerLengthExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class TorquePerLengthUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class TorquePerLengthUnitExtension
+{
+
+    public static TorquePerLength IfNullSetToZero(this TorquePerLength? local)
     {
-
-        public static TorquePerLength IfNullSetToZero(this TorquePerLength? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return TorquePerLength.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static TorquePerLength? Abs(this TorquePerLength? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return TorquePerLength.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static TorquePerLength? Abs(this TorquePerLength? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/TorquePerLength/TorquePerLengthExtension.cs
+++ b/EngineeringUnits/CombinedUnits/TorquePerLength/TorquePerLengthExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class TorquePerLengthUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/TorquePerLength/TorquePerLengthExtension.cs
+++ b/EngineeringUnits/CombinedUnits/TorquePerLength/TorquePerLengthExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Volume/VolumeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Volume/VolumeExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/Volume/VolumeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Volume/VolumeExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class VolumeUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/Volume/VolumeExtension.cs
+++ b/EngineeringUnits/CombinedUnits/Volume/VolumeExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class VolumeUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class VolumeUnitExtension
+{
+
+    public static Volume IfNullSetToZero(this Volume? local)
     {
-
-        public static Volume IfNullSetToZero(this Volume? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return Volume.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static Volume? Abs(this Volume? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return Volume.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static Volume? Abs(this Volume? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/VolumeCost/VolumeCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumeCost/VolumeCostExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/VolumeCost/VolumeCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumeCost/VolumeCostExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class VolumeCostUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class VolumeCostUnitExtension
+{
+
+    public static VolumeCost IfNullSetToZero(this VolumeCost? local)
     {
-
-        public static VolumeCost IfNullSetToZero(this VolumeCost? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return VolumeCost.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static VolumeCost? Abs(this VolumeCost? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return VolumeCost.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static VolumeCost? Abs(this VolumeCost? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/VolumeCost/VolumeCostExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumeCost/VolumeCostExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class VolumeCostUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/VolumeFlow/VolumeFlowExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumeFlow/VolumeFlowExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class VolumeFlowUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/VolumeFlow/VolumeFlowExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumeFlow/VolumeFlowExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/VolumeFlow/VolumeFlowExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumeFlow/VolumeFlowExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class VolumeFlowUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class VolumeFlowUnitExtension
+{
+
+    public static VolumeFlow IfNullSetToZero(this VolumeFlow? local)
     {
-
-        public static VolumeFlow IfNullSetToZero(this VolumeFlow? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return VolumeFlow.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static VolumeFlow? Abs(this VolumeFlow? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return VolumeFlow.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static VolumeFlow? Abs(this VolumeFlow? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/VolumePerLength/VolumePerLengthExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumePerLength/VolumePerLengthExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class VolumePerLengthUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class VolumePerLengthUnitExtension
+{
+
+    public static VolumePerLength IfNullSetToZero(this VolumePerLength? local)
     {
-
-        public static VolumePerLength IfNullSetToZero(this VolumePerLength? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return VolumePerLength.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static VolumePerLength? Abs(this VolumePerLength? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return VolumePerLength.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static VolumePerLength? Abs(this VolumePerLength? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/VolumePerLength/VolumePerLengthExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumePerLength/VolumePerLengthExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/VolumePerLength/VolumePerLengthExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumePerLength/VolumePerLengthExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class VolumePerLengthUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/VolumetricHeatTransferCoefficient/VolumetricHeatTransferCoefficientExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumetricHeatTransferCoefficient/VolumetricHeatTransferCoefficientExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class VolumetricHeatTransferCoefficientUnitExtension
     {
 

--- a/EngineeringUnits/CombinedUnits/VolumetricHeatTransferCoefficient/VolumetricHeatTransferCoefficientExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumetricHeatTransferCoefficient/VolumetricHeatTransferCoefficientExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class VolumetricHeatTransferCoefficientUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class VolumetricHeatTransferCoefficientUnitExtension
+{
+
+    public static VolumetricHeatTransferCoefficient IfNullSetToZero(this VolumetricHeatTransferCoefficient? local)
     {
-
-        public static VolumetricHeatTransferCoefficient IfNullSetToZero(this VolumetricHeatTransferCoefficient? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return VolumetricHeatTransferCoefficient.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static VolumetricHeatTransferCoefficient? Abs(this VolumetricHeatTransferCoefficient? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return VolumetricHeatTransferCoefficient.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static VolumetricHeatTransferCoefficient? Abs(this VolumetricHeatTransferCoefficient? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/VolumetricHeatTransferCoefficient/VolumetricHeatTransferCoefficientExtension.cs
+++ b/EngineeringUnits/CombinedUnits/VolumetricHeatTransferCoefficient/VolumetricHeatTransferCoefficientExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/WarpingMomentOfInertia/WarpingMomentOfInertiaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/WarpingMomentOfInertia/WarpingMomentOfInertiaExtension.cs
@@ -1,37 +1,36 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 
-namespace EngineeringUnits
-{                   
-    // This class is auto-generated, changes to the file will be overwritten!
-    public static class WarpingMomentOfInertiaUnitExtension
+namespace EngineeringUnits;
+
+// This class is auto-generated, changes to the file will be overwritten!
+public static class WarpingMomentOfInertiaUnitExtension
+{
+
+    public static WarpingMomentOfInertia IfNullSetToZero(this WarpingMomentOfInertia? local)
     {
-
-        public static WarpingMomentOfInertia IfNullSetToZero(this WarpingMomentOfInertia? local)
+        if (local is not null)
         {
-            if (local is not null)
-            {
-                return local;
-            }
-
-            return WarpingMomentOfInertia.Zero;
+            return local;
         }
 
-
-        /// <summary>
-        /// Returns the absolute value
-        /// </summary>
-        [return: NotNullIfNotNull(nameof(a))]
-        public static WarpingMomentOfInertia? Abs(this WarpingMomentOfInertia? a)
-        {
-            if (a is null)
-                return null;
-
-            if (a.GetBaseValue() > 0)
-                return a;
-
-            return (-a)!;
-        }
-
+        return WarpingMomentOfInertia.Zero;
     }
-}                   
+
+
+    /// <summary>
+    /// Returns the absolute value
+    /// </summary>
+    [return: NotNullIfNotNull(nameof(a))]
+    public static WarpingMomentOfInertia? Abs(this WarpingMomentOfInertia? a)
+    {
+        if (a is null)
+            return null;
+
+        if (a.GetBaseValue() > 0)
+            return a;
+
+        return (-a)!;
+    }
+
+}               

--- a/EngineeringUnits/CombinedUnits/WarpingMomentOfInertia/WarpingMomentOfInertiaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/WarpingMomentOfInertia/WarpingMomentOfInertiaExtension.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits;

--- a/EngineeringUnits/CombinedUnits/WarpingMomentOfInertia/WarpingMomentOfInertiaExtension.cs
+++ b/EngineeringUnits/CombinedUnits/WarpingMomentOfInertia/WarpingMomentOfInertiaExtension.cs
@@ -2,7 +2,8 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace EngineeringUnits
-{
+{                   
+    // This class is auto-generated, changes to the file will be overwritten!
     public static class WarpingMomentOfInertiaUnitExtension
     {
 

--- a/EngineeringUnits/UnknownUnitExtensions.cs
+++ b/EngineeringUnits/UnknownUnitExtensions.cs
@@ -163,6 +163,8 @@ public static class UnknownUnitExtensions
             return (PressureChangeRate?)toCast;
         if (toCast == PressureUnit.SI.Unit)
             return (Pressure?)toCast;
+        if (toCast == SnapUnit.SI.Unit)
+            return (Snap?)toCast;
         if (toCast == SpecificEntropyUnit.SI.Unit)
             return (SpecificEntropy?)toCast;
         if (toCast == SpecificHeatCapacityUnit.SI.Unit)

--- a/Sandbox/Program.cs
+++ b/Sandbox/Program.cs
@@ -819,8 +819,11 @@ public class Program
 
 
         // Test Snap
-        var s = Snap.FromMeterPerSecond4(10);
-        Console.WriteLine(s.ToString());
+        var s1 = Snap.FromMeterPerSecond4(10);
+        Console.WriteLine(s1.ToString());
+
+        Snap s2 = Acceleration.FromMeterPerSecondSquared(2) / Duration.FromSecond(2).Pow(2);
+        Console.WriteLine(s2.ToString());
     }
 
     public partial record AreaCostUnit : UnitTypebase

--- a/Sandbox/Program.cs
+++ b/Sandbox/Program.cs
@@ -772,51 +772,55 @@ public class Program
 
 
 
-        // This tests the method used by the Aggregate function in UnitMath.Sum()
-        // (1) From Kelvin
-        var T1a = Temperature.FromKelvin(10);
-        var T1b = Temperature.FromKelvin(20);
+        //// This tests the method used by the Aggregate function in UnitMath.Sum()
+        //// (1) From Kelvin
+        //var T1a = Temperature.FromKelvin(10);
+        //var T1b = Temperature.FromKelvin(20);
 
-        // The Aggregate() method in Sum() does this:
-        var T1_UU = new UnknownUnit(0m, T1a) + T1a + T1b;
+        //// The Aggregate() method in Sum() does this:
+        //var T1_UU = new UnknownUnit(0m, T1a) + T1a + T1b;
 
-        // This is correct if temperatures constructed from Kelvin
-        if (Temperature.FromKelvin(T1a.Kelvin + T1b.Kelvin) != (Temperature)T1_UU)
-        {
-            throw new Exception($"{Temperature.FromKelvin(T1a.Kelvin + T1b.Kelvin)} is not equal to {(Temperature)T1_UU}");
-        }
+        //// This is correct if temperatures constructed from Kelvin
+        //if (Temperature.FromKelvin(T1a.Kelvin + T1b.Kelvin) != (Temperature)T1_UU)
+        //{
+        //throw new Exception($"{Temperature.FromKelvin(T1a.Kelvin + T1b.Kelvin)} is not equal to {(Temperature)T1_UU}");
+        //}
 
-        // (2) From Degrees C
-        var T2a = Temperature.FromDegreeCelsius(10);
-        var T2b = Temperature.FromDegreeCelsius(20);
+        //// (2) From Degrees C
+        //var T2a = Temperature.FromDegreeCelsius(10);
+        //var T2b = Temperature.FromDegreeCelsius(20);
 
-        // The Aggregate() method in Sum() currently does this
-        var T2_UU = new UnknownUnit(0m, T2a) + T2a + T2b;
-        if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU)
-        {
-            // This causes the original issue
-            // throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU}");
-        }
+        //// The Aggregate() method in Sum() currently does this
+        //var T2_UU = new UnknownUnit(0m, T2a) + T2a + T2b;
+        //if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU)
+        //{
+        //// This causes the original issue
+        //// throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU}");
+        //}
 
-        // For Temperature from DegreeCelsius, it should do this:
-        var T2_UU_fixedCelsius = new UnknownUnit(-273.15m, T2a) + T2a + T2b;
-        if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU_fixedCelsius)
-        {
-            throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU_fixedCelsius}");
-        }
+        //// For Temperature from DegreeCelsius, it should do this:
+        //var T2_UU_fixedCelsius = new UnknownUnit(-273.15m, T2a) + T2a + T2b;
+        //if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU_fixedCelsius)
+        //{
+        //throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU_fixedCelsius}");
+        //}
 
-        // More generally, for all temperatues:
-        var T2_UU_fixedTemp1 = new UnknownUnit(Temperature.Zero) + T2a + T2b;
-        var T2_UU_fixedTemp2 = new UnknownUnit(0m, T2a.ToUnit(TemperatureUnit.SI)) + T2a + T2b;
-        if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU_fixedTemp1)
-        {
-            throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU_fixedTemp1}");
-        }
-        if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU_fixedTemp2)
-        {
-            throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU_fixedTemp2}");
-        }
+        //// More generally, for all temperatues:
+        //var T2_UU_fixedTemp1 = new UnknownUnit(Temperature.Zero) + T2a + T2b;
+        //var T2_UU_fixedTemp2 = new UnknownUnit(0m, T2a.ToUnit(TemperatureUnit.SI)) + T2a + T2b;
+        //if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU_fixedTemp1)
+        //{
+        //throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU_fixedTemp1}");
+        //}
+        //if (Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin) != (Temperature)T2_UU_fixedTemp2)
+        //{
+        //throw new Exception($"{Temperature.FromKelvin(T2a.Kelvin + T2b.Kelvin)} is not equal to {(Temperature)T2_UU_fixedTemp2}");
+        //}
 
+
+        // Test Snap
+        var s = Snap.FromMeterPerSecond4(10);
+        Console.WriteLine(s.ToString());
     }
 
     public partial record AreaCostUnit : UnitTypebase


### PR DESCRIPTION
Added `Snap`, i.e. the 4th derivative of `Length`, so now there is 

`Length` > `Speed` > `Acceleration` > `Jerk` > `Snap`

I don't think there is a good unit naming continuation to continue "Squared">"Cubed">..., so I went for "4". Maybe you'll find something better.

I also cleaned up some code-gen stuff while at it (simplified namespace definition, added auto-gen comment for Extensions).
