### PR TITLE
Fix us dollar units

### DIFF
--- a/EngineeringUnits/CombinedUnits/LengthCost/LengthCostEnum.cs
+++ b/EngineeringUnits/CombinedUnits/LengthCost/LengthCostEnum.cs
@@ -2,7 +2,7 @@ namespace EngineeringUnits.Units;
 public partial record LengthCostUnit : UnitTypebase
 {
     public static readonly LengthCostUnit SI = new(CostUnit.SI, LengthUnit.SI);
-    public static readonly LengthCostUnit DollarPerMeter = new(CostUnit.USDollar, LengthUnit.Meter);
+    public static readonly LengthCostUnit USDollarPerMeter = new(CostUnit.USDollar, LengthUnit.Meter);
     public static readonly LengthCostUnit EuroPerMeter = new(CostUnit.Euro, LengthUnit.Meter);
 
     public LengthCostUnit(CostUnit cost, LengthUnit length)

--- a/EngineeringUnits/CombinedUnits/LengthCost/LengthCostGet.cs
+++ b/EngineeringUnits/CombinedUnits/LengthCost/LengthCostGet.cs
@@ -13,7 +13,7 @@ public partial class LengthCost
     /// <summary>
     /// Get LengthCost in DollarPerMeter.
     /// </summary>
-    public double DollarPerMeter => As(LengthCostUnit.DollarPerMeter);
+    public double DollarPerMeter => As(LengthCostUnit.USDollarPerMeter);
     /// <summary>
     /// Get LengthCost in EuroPerMeter.
     /// </summary>

--- a/EngineeringUnits/CombinedUnits/LengthCost/LengthCostGet.cs
+++ b/EngineeringUnits/CombinedUnits/LengthCost/LengthCostGet.cs
@@ -11,9 +11,9 @@ public partial class LengthCost
     /// </summary>
     public double SI => As(LengthCostUnit.SI);
     /// <summary>
-    /// Get LengthCost in DollarPerMeter.
+    /// Get LengthCost in USDollarPerMeter.
     /// </summary>
-    public double DollarPerMeter => As(LengthCostUnit.USDollarPerMeter);
+    public double USDollarPerMeter => As(LengthCostUnit.USDollarPerMeter);
     /// <summary>
     /// Get LengthCost in EuroPerMeter.
     /// </summary>

--- a/EngineeringUnits/CombinedUnits/LengthCost/LengthCostSet.cs
+++ b/EngineeringUnits/CombinedUnits/LengthCost/LengthCostSet.cs
@@ -20,16 +20,16 @@ public partial class LengthCost
         return new LengthCost((double)SI, LengthCostUnit.SI);
     }
     /// <summary>
-    /// Get LengthCost from DollarPerMeter.
+    /// Get LengthCost from USDollarPerMeter.
     /// </summary>
     /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-    [return: NotNullIfNotNull(nameof(DollarPerMeter))]
-    public static LengthCost? FromDollarPerMeter(double? DollarPerMeter)
+    [return: NotNullIfNotNull(nameof(USDollarPerMeter))]
+    public static LengthCost? FromUSDollarPerMeter(double? USDollarPerMeter)
     {
-        if (DollarPerMeter is null)
+        if (USDollarPerMeter is null)
             return null;
         
-        return new LengthCost((double)DollarPerMeter, LengthCostUnit.USDollarPerMeter);
+        return new LengthCost((double)USDollarPerMeter, LengthCostUnit.USDollarPerMeter);
     }
     /// <summary>
     /// Get LengthCost from EuroPerMeter.

--- a/EngineeringUnits/CombinedUnits/LengthCost/LengthCostSet.cs
+++ b/EngineeringUnits/CombinedUnits/LengthCost/LengthCostSet.cs
@@ -29,7 +29,7 @@ public partial class LengthCost
         if (DollarPerMeter is null)
             return null;
         
-        return new LengthCost((double)DollarPerMeter, LengthCostUnit.DollarPerMeter);
+        return new LengthCost((double)DollarPerMeter, LengthCostUnit.USDollarPerMeter);
     }
     /// <summary>
     /// Get LengthCost from EuroPerMeter.


### PR DESCRIPTION
Should use `USDollar` everywhere for consistency. `LenghtCost` still had `DollarPerMeter`. Replaced by `USDollarPerMeter`.