### PR TITLE
Fixes temperature SI unit in UnitTypebase

### DIFF
--- a/EngineeringUnits/UnitTypebase.cs
+++ b/EngineeringUnits/UnitTypebase.cs
@@ -105,7 +105,7 @@ public record UnitTypebase
            BaseunitType.length => "m",
            BaseunitType.mass => "g",
            BaseunitType.electricCurrent => "A",
-           BaseunitType.temperature => "",
+           BaseunitType.temperature => "K",
            BaseunitType.amountOfSubstance => "mol",
            BaseunitType.luminousIntensity => "cd",
            _ => "",
@@ -145,7 +145,7 @@ public record UnitTypebase
 
     public static UnitSystem operator *(UnitTypebase left, UnitTypebase right)
     {
-        return left.Unit* right.Unit;
+        return left.Unit * right.Unit;
     }
 
     public static UnitSystem operator *(UnitSystem left, UnitTypebase right)


### PR DESCRIPTION
- Corrects the SI unit for temperature to Kelvin ("K").

- An empty string could cause potential runtime issues when the unit for temperature would get requested by BaseUnitSISymbol