### PR TITLE
Add prefixed Coulomb units

### DIFF
--- a/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeEnum.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeEnum.cs
@@ -2,26 +2,36 @@
 
 public partial record ElectricChargeUnit : UnitTypebase
 {
-
     public static readonly ElectricChargeUnit SI = new(ElectricCurrentUnit.SI, DurationUnit.SI, "C");
     public static readonly ElectricChargeUnit Coulomb = new(ElectricCurrentUnit.Ampere, DurationUnit.Second, "C");
+
+    // Large units
+    public static readonly ElectricChargeUnit Teracoulomb = new(PreFix.tera, Coulomb);
+    public static readonly ElectricChargeUnit Gigacoulomb = new(PreFix.giga, Coulomb);
+    public static readonly ElectricChargeUnit Megacoulomb = new(PreFix.mega, Coulomb);
+    public static readonly ElectricChargeUnit Kilocoulomb = new(PreFix.kilo, Coulomb);
+
+    // Small units
+    public static readonly ElectricChargeUnit Millicoulomb = new(PreFix.milli, Coulomb);
+    public static readonly ElectricChargeUnit Microcoulomb = new(PreFix.micro, Coulomb);
+    public static readonly ElectricChargeUnit Nanocoulomb = new(PreFix.nano, Coulomb);
+    public static readonly ElectricChargeUnit Picocoulomb = new(PreFix.pico, Coulomb);
+
+    // Ampere-hour based units
     public static readonly ElectricChargeUnit AmpereHour = new(ElectricCurrentUnit.Ampere, DurationUnit.Hour, "A-h");
     public static readonly ElectricChargeUnit KiloampereHour = new(PreFix.kilo, AmpereHour);
     public static readonly ElectricChargeUnit MegaampereHour = new(PreFix.mega, AmpereHour);
     public static readonly ElectricChargeUnit MilliampereHour = new(PreFix.milli, AmpereHour);
 
-    public ElectricChargeUnit(ElectricCurrentUnit electricCurrent, DurationUnit duration, string NewSymbol)
+    public ElectricChargeUnit(ElectricCurrentUnit electricCurrent, DurationUnit duration, string newSymbol)
     {
-        Unit = new UnitSystem(electricCurrent * duration, NewSymbol);
+        Unit = new UnitSystem(electricCurrent * duration, newSymbol);
     }
 
     public ElectricChargeUnit(PreFix SI, ElectricChargeUnit unit) : base(SI, unit) { }
 
     public override string ToString()
     {
-        if (Unit.Symbol is not null)
-            return $"{Unit.Symbol}";
-
-        return $"{Unit}";
+        return Unit.Symbol is not null ? $"{Unit.Symbol}" : $"{Unit}";
     }
 }

--- a/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeGet.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeGet.cs
@@ -15,6 +15,38 @@ public partial class ElectricCharge
     /// </summary>
     public double Coulomb => As(ElectricChargeUnit.Coulomb);
     /// <summary>
+    /// Get ElectricCharge in Teracoulomb.
+    /// </summary>
+    public double Teracoulomb => As(ElectricChargeUnit.Teracoulomb);
+    /// <summary>
+    /// Get ElectricCharge in Gigacoulomb.
+    /// </summary>
+    public double Gigacoulomb => As(ElectricChargeUnit.Gigacoulomb);
+    /// <summary>
+    /// Get ElectricCharge in Megacoulomb.
+    /// </summary>
+    public double Megacoulomb => As(ElectricChargeUnit.Megacoulomb);
+    /// <summary>
+    /// Get ElectricCharge in Kilocoulomb.
+    /// </summary>
+    public double Kilocoulomb => As(ElectricChargeUnit.Kilocoulomb);
+    /// <summary>
+    /// Get ElectricCharge in Millicoulomb.
+    /// </summary>
+    public double Millicoulomb => As(ElectricChargeUnit.Millicoulomb);
+    /// <summary>
+    /// Get ElectricCharge in Microcoulomb.
+    /// </summary>
+    public double Microcoulomb => As(ElectricChargeUnit.Microcoulomb);
+    /// <summary>
+    /// Get ElectricCharge in Nanocoulomb.
+    /// </summary>
+    public double Nanocoulomb => As(ElectricChargeUnit.Nanocoulomb);
+    /// <summary>
+    /// Get ElectricCharge in Picocoulomb.
+    /// </summary>
+    public double Picocoulomb => As(ElectricChargeUnit.Picocoulomb);
+    /// <summary>
     /// Get ElectricCharge in AmpereHour.
     /// </summary>
     public double AmpereHour => As(ElectricChargeUnit.AmpereHour);

--- a/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeSet.cs
+++ b/EngineeringUnits/CombinedUnits/ElectricCharge/ElectricChargeSet.cs
@@ -32,6 +32,102 @@ public partial class ElectricCharge
         return new ElectricCharge((double)Coulomb, ElectricChargeUnit.Coulomb);
     }
     /// <summary>
+    /// Get ElectricCharge from Teracoulomb.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(Teracoulomb))]
+    public static ElectricCharge? FromTeracoulomb(double? Teracoulomb)
+    {
+        if (Teracoulomb is null)
+            return null;
+        
+        return new ElectricCharge((double)Teracoulomb, ElectricChargeUnit.Teracoulomb);
+    }
+    /// <summary>
+    /// Get ElectricCharge from Gigacoulomb.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(Gigacoulomb))]
+    public static ElectricCharge? FromGigacoulomb(double? Gigacoulomb)
+    {
+        if (Gigacoulomb is null)
+            return null;
+        
+        return new ElectricCharge((double)Gigacoulomb, ElectricChargeUnit.Gigacoulomb);
+    }
+    /// <summary>
+    /// Get ElectricCharge from Megacoulomb.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(Megacoulomb))]
+    public static ElectricCharge? FromMegacoulomb(double? Megacoulomb)
+    {
+        if (Megacoulomb is null)
+            return null;
+        
+        return new ElectricCharge((double)Megacoulomb, ElectricChargeUnit.Megacoulomb);
+    }
+    /// <summary>
+    /// Get ElectricCharge from Kilocoulomb.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(Kilocoulomb))]
+    public static ElectricCharge? FromKilocoulomb(double? Kilocoulomb)
+    {
+        if (Kilocoulomb is null)
+            return null;
+        
+        return new ElectricCharge((double)Kilocoulomb, ElectricChargeUnit.Kilocoulomb);
+    }
+    /// <summary>
+    /// Get ElectricCharge from Millicoulomb.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(Millicoulomb))]
+    public static ElectricCharge? FromMillicoulomb(double? Millicoulomb)
+    {
+        if (Millicoulomb is null)
+            return null;
+        
+        return new ElectricCharge((double)Millicoulomb, ElectricChargeUnit.Millicoulomb);
+    }
+    /// <summary>
+    /// Get ElectricCharge from Microcoulomb.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(Microcoulomb))]
+    public static ElectricCharge? FromMicrocoulomb(double? Microcoulomb)
+    {
+        if (Microcoulomb is null)
+            return null;
+        
+        return new ElectricCharge((double)Microcoulomb, ElectricChargeUnit.Microcoulomb);
+    }
+    /// <summary>
+    /// Get ElectricCharge from Nanocoulomb.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(Nanocoulomb))]
+    public static ElectricCharge? FromNanocoulomb(double? Nanocoulomb)
+    {
+        if (Nanocoulomb is null)
+            return null;
+        
+        return new ElectricCharge((double)Nanocoulomb, ElectricChargeUnit.Nanocoulomb);
+    }
+    /// <summary>
+    /// Get ElectricCharge from Picocoulomb.
+    /// </summary>
+    /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+    [return: NotNullIfNotNull(nameof(Picocoulomb))]
+    public static ElectricCharge? FromPicocoulomb(double? Picocoulomb)
+    {
+        if (Picocoulomb is null)
+            return null;
+        
+        return new ElectricCharge((double)Picocoulomb, ElectricChargeUnit.Picocoulomb);
+    }
+    /// <summary>
     /// Get ElectricCharge from AmpereHour.
     /// </summary>
     /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,13 @@ steps:
 
 - bash: echo $(Build)
 
+# Install .NET 6 runtime (for backward compatibility)
+- task: UseDotNet@2
+  inputs:
+    packageType: 'runtime'
+    version: '6.0.x'
+
+# Install .NET 8 SDK (for current builds)
 - task: UseDotNet@2
   inputs:
     packageType: 'sdk'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,11 @@ steps:
 
 - bash: echo $(Build)
 
+- task: UseDotNet@2
+  inputs:
+    packageType: 'sdk'
+    version: '8.x'
+    
 
 - task: NuGetToolInstaller@1
   inputs:


### PR DESCRIPTION
- Added large and small prefixed Coulomb units (T, G, M, k, m, μ, n, p)
- Simplified `ToString()` implementation using conditional expression
- Minor formatting improvements for readability

Some of methods like `ElectricCharge.FromNanocoulomb()` where not generated. Currently I use: 
`ElectricCharge.From(10.0, new ElectricChargeUnit(PreFix.nano, ElectricChargeUnit.Coulomb));` but I would like to have FromNanocoulomb() as its more readable. Thanks :)