### PR TITLE
Add GetValueAsDecimal extension and AsDecimal to codegen template

### DIFF
--- a/CodeGen/Code/UnitGenerator.cs
+++ b/CodeGen/Code/UnitGenerator.cs
@@ -103,6 +103,7 @@ internal class UnitGenerator
                            return From((double)value, unit);
                        }
                        public double As({{Variable}}Unit ReturnInThisUnit) => this.GetValueAsDouble(ReturnInThisUnit);
+                       public decimal AsDecimal({{Variable}}Unit ReturnInThisUnit) => this.GetValueAsDecimal(ReturnInThisUnit);
                        public {{Variable}} ToUnit({{Variable}}Unit selectedUnit) => new(this.GetValueAs(selectedUnit.Unit), selectedUnit);
                        public static {{Variable}} Zero => new(0, {{Variable}}Unit.SI);
                        public static {{Variable}} NaN => new(double.NaN, {{Variable}}Unit.SI);

--- a/EngineeringUnits/BaseUnitExtensions.cs
+++ b/EngineeringUnits/BaseUnitExtensions.cs
@@ -98,6 +98,7 @@ public static class BaseUnitExtensions
     }
 
     public static double GetValueAsDouble(this BaseUnit From, UnitSystem To) => (double)From.GetValueAs2(To);
+    public static decimal GetValueAsDecimal(this BaseUnit From, UnitSystem To) => (decimal)From.GetValueAs2(To);
 
     public static string DisplaySymbol(this BaseUnit From, string? format = null) => From.Unit.ReduceUnits().ToString(format, null);
 


### PR DESCRIPTION
## Summary
- Adds `GetValueAsDecimal` extension method to `BaseUnitExtensions` mirroring `GetValueAsDouble`
- Adds `AsDecimal(Unit)` to the codegen template so all generated unit classes support higher-precision decimal output