### PR TITLE
Add ToSIString extension methods to BaseUnitExtensions

### DIFF
--- a/EngineeringUnits/BaseUnitExtensions.cs
+++ b/EngineeringUnits/BaseUnitExtensions.cs
@@ -101,6 +101,45 @@ public static class BaseUnitExtensions
 
     public static string DisplaySymbol(this BaseUnit From, string? format = null) => From.Unit.ReduceUnits().ToString(format, null);
 
+    /// <summary>
+    /// Converts the BaseUnit to SI units and returns a string representation.
+    /// </summary>
+    /// <param name="unit">The BaseUnit to convert to SI.</param>
+    /// <returns>String representation of the value in SI units with SI unit symbol.</returns>
+    public static string ToSIString(this BaseUnit unit)
+    {
+        return unit.ToSIString("g4");
+    }
+
+    /// <summary>
+    /// Converts the BaseUnit to SI units and returns a string representation with the specified format.
+    /// </summary>
+    /// <param name="unit">The BaseUnit to convert to SI.</param>
+    /// <param name="format">The format string for the value (e.g., "g4", "f2", "e3").</param>
+    /// <returns>String representation of the value in SI units with SI unit symbol.</returns>
+    public static string ToSIString(this BaseUnit unit, string format)
+    {
+        // Get the SI unit system for this unit
+        var siUnitSystem = unit.Unit.GetSIUnitsystem();
+
+        // Convert the value to SI
+        DecimalSafe siValue = unit.GetValueAs(siUnitSystem);
+
+        // Get the SI unit symbol
+        var siSymbol = unit.GetStandardSymbol(siUnitSystem) ?? siUnitSystem.ToString();
+
+        // Format the value
+        var formattedValue = format[0] switch
+        {
+            'V' or 'v' => siValue.DisplaySignificantDigits(int.Parse(format.Remove(0, 1))),
+            'S' or 's' => siValue.DisplaySignificantDigits(int.Parse(format.Remove(0, 1))),
+            _ => siValue.ToString(format, System.Globalization.CultureInfo.InvariantCulture)
+        };
+
+        // Return formatted string with SI unit
+        return $"{formattedValue} {siSymbol}".Trim();
+    }
+
     internal static DecimalSafe GetBaseValue(this BaseUnit From)
     {
         if (From.Unit.IsSIUnit())

--- a/UnitTests/ToSIStringTests.cs
+++ b/UnitTests/ToSIStringTests.cs
@@ -1,0 +1,96 @@
+using EngineeringUnits;
+using EngineeringUnits.Units;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UnitTests;
+
+[TestClass]
+public class ToSIStringTests
+{
+    [TestMethod]
+    public void ToSIString_LengthInNonSI_ReturnsMeters()
+    {
+        var length = new Length(1000, LengthUnit.Millimeter);
+        var result = length.ToSIString();
+
+        Assert.IsTrue(result.EndsWith("m"), $"Expected SI symbol 'm', got: {result}");
+        Assert.IsTrue(result.Contains("1"), $"Expected value ~1, got: {result}");
+    }
+
+    [TestMethod]
+    public void ToSIString_LengthAlreadySI_ReturnsSameValue()
+    {
+        var length = new Length(5, LengthUnit.Meter);
+        var result = length.ToSIString();
+
+        Assert.AreEqual("5 m", result);
+    }
+
+    [TestMethod]
+    public void ToSIString_WithFormat_F2()
+    {
+        var length = new Length(1, LengthUnit.Meter);
+        var result = length.ToSIString("f2");
+
+        Assert.AreEqual("1.00 m", result);
+    }
+
+    [TestMethod]
+    public void ToSIString_WithFormat_E2()
+    {
+        var length = new Length(1000, LengthUnit.Meter);
+        var result = length.ToSIString("e2");
+
+        Assert.AreEqual("1.00e+003 m", result);
+    }
+
+    [TestMethod]
+    public void ToSIString_WithFormat_SignificantDigits_V3()
+    {
+        var length = new Length(123.456, LengthUnit.Meter);
+        var result = length.ToSIString("v3");
+
+        Assert.IsTrue(result.Contains("123"), $"Expected 3 significant digits, got: {result}");
+        Assert.IsTrue(result.EndsWith("m"), $"Expected SI symbol 'm', got: {result}");
+    }
+
+    [TestMethod]
+    public void ToSIString_Mass_KilogramIsSI()
+    {
+        var mass = new Mass(500, MassUnit.Gram);
+        var result = mass.ToSIString();
+
+        Assert.IsTrue(result.EndsWith("kg"), $"Expected SI symbol 'kg', got: {result}");
+        Assert.IsTrue(result.Contains("0.5"), $"Expected 0.5 kg, got: {result}");
+    }
+
+    [TestMethod]
+    public void ToSIString_Temperature_KelvinIsSI()
+    {
+        var temp = new Temperature(100, TemperatureUnit.DegreeCelsius);
+        var result = temp.ToSIString();
+
+        Assert.IsTrue(result.EndsWith("K"), $"Expected SI symbol 'K', got: {result}");
+    }
+
+    [TestMethod]
+    public void ToSIString_Pressure_ShowsSIDimensions()
+    {
+        var pressure = new Pressure(1, PressureUnit.Bar);
+        var result = pressure.ToSIString();
+
+        // Pressure SI is Pa but GetStandardSymbol falls back to raw dimensions
+        Assert.IsTrue(result.Contains("1"), $"Expected value containing 1e+05, got: {result}");
+        Assert.IsTrue(result.Contains("kg"), $"Expected SI dimensions with kg, got: {result}");
+    }
+
+    [TestMethod]
+    public void ToSIString_DefaultFormat_UsesG4()
+    {
+        var length = new Length(1.23456789, LengthUnit.Meter);
+        var defaultResult = length.ToSIString();
+        var g4Result = length.ToSIString("g4");
+
+        Assert.AreEqual(g4Result, defaultResult);
+    }
+}


### PR DESCRIPTION
## Summary
Adds two `ToSIString()` extension methods to `BaseUnitExtensions` that convert any `BaseUnit` to its SI representation and return a formatted string with the SI symbol.

- `ToSIString()` — defaults to `"g4"` format
- `ToSIString(string format)` — supports standard numeric formats plus `V`/`S` for significant digits display

Useful for frontend display where you want to show values in SI units regardless of the unit the value was created with.

## Tests
9 tests covering default format, custom formats (f2, e2, v3), SI conversion from non-SI units, and various unit types (Length, Mass, Temperature, Pressure).